### PR TITLE
Remove unused request variable in AboutController

### DIFF
--- a/src/AppBundle/Controller/AboutController.php
+++ b/src/AppBundle/Controller/AboutController.php
@@ -4,14 +4,13 @@ namespace AppBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
 
 class AboutController extends Controller
 {
     /**
      * @Route("/sobre", name="about")
      */
-    public function indexAction(Request $request)
+    public function indexAction()
     {
         return $this->render('about/index.html.twig');
     }


### PR DESCRIPTION
## Description

In order to remove a minor issue reported in scrutinizer tool (see the issue [here](https://scrutinizer-ci.com/g/QEdu/qedu-hub/issues/master/files/src/AppBundle/Controller/AboutController.php?orderField=path&order=asc&honorSelectedPaths=0)), we are going to remove an unused request variable in AboutController.
