### PR TITLE
Brazil learning static

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=992, initial-scale=1.0" />
     <meta name="description" content="{% block description %}{% endblock %}" />
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://www.qedu.org.br/">
+    <meta property="og:url" content="{{ url(app.request.attributes.get("_route"), app.request.attributes.get("_route_params")) }}">
     <meta property="og:site_name" content="QEdu: Aprendizado em foco">
     <meta property="og:title" content="{% block og_title %}{% endblock %}">
     <meta property="og:description" content="{% block og_description %}{% endblock %}">

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -3,17 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <title>{% block title %}QEdu: Use dados. Transforme a educação.{% endblock %}</title>
-    
+
     <meta name="viewport" content="width=992, initial-scale=1.0" />
-    <meta name="author" content="QEdu" />
     <meta name="description" content="{% block description %}{% endblock %}" />
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://www.qedu.org.br/">
     <meta property="og:site_name" content="QEdu: Aprendizado em foco">
     <meta property="og:title" content="{% block og_title %}{% endblock %}">
     <meta property="og:description" content="{% block og_description %}{% endblock %}">
-    <meta property="fb:admins" content="100000394680280,742652402, 1169118080">
-    <meta property="og:locale" content="pt_BR">
     <meta property="og:image" content="http://d2jaknbl34vcit.cloudfront.net/img/provabrasil/qedu_opengraph_logo.png">
     <link type="image/x-icon" href="http://d2jaknbl34vcit.cloudfront.net/img/provabrasil/favicon.ico" rel="shortcut icon" />
 

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -4,15 +4,18 @@
     <meta charset="UTF-8" />
     <title>{% block title %}QEdu: Use dados. Transforme a educação.{% endblock %}</title>
 
+    {% set current_url = url(app.request.attributes.get("_route"), app.request.attributes.get("_route_params")) %}
+
     <meta name="viewport" content="width=992, initial-scale=1.0" />
     <meta name="description" content="{% block description %}{% endblock %}" />
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ url(app.request.attributes.get("_route"), app.request.attributes.get("_route_params")) }}">
+    <meta property="og:url" content="{{ current_url }}">
     <meta property="og:site_name" content="QEdu: Aprendizado em foco">
     <meta property="og:title" content="{% block og_title %}{% endblock %}">
     <meta property="og:description" content="{% block og_description %}{% endblock %}">
     <meta property="og:image" content="http://d2jaknbl34vcit.cloudfront.net/img/provabrasil/qedu_opengraph_logo.png">
     <link type="image/x-icon" href="http://d2jaknbl34vcit.cloudfront.net/img/provabrasil/favicon.ico" rel="shortcut icon" />
+    <link rel="canonical" href="{{ current_url }}" />
 
     {% block stylesheets %}{% endblock %}
 

--- a/app/Resources/views/learning/banner.html.twig
+++ b/app/Resources/views/learning/banner.html.twig
@@ -1,6 +1,6 @@
 <section class="excelencia-equidade-banner-ct">
-    <a href="http://www.fundacaolemann.org.br/excelencia-com-equidade/?utm_source=qedu&amp;utm_medium=banner&amp;utm_campaign=divulgacao-excelencia-equidade" target="_blank">
-        <img src="https://qedu-assets.s3.amazonaws.com/banner_excelencia_equidade_mini.jpg"
+  <a href="http://www.fundacaolemann.org.br/excelencia-com-equidade/?utm_source=qedu&amp;utm_medium=banner&amp;utm_campaign=divulgacao-excelencia-equidade" target="_blank">
+    <img src="https://qedu-assets.s3.amazonaws.com/banner_excelencia_equidade_mini.jpg"
              alt="Excelência com Equidade - Os desafios dos anos finais do ensino fundamental - Clique e saiba mais">
-    </a>
+  </a>
 </section>

--- a/app/Resources/views/learning/banner.html.twig
+++ b/app/Resources/views/learning/banner.html.twig
@@ -1,0 +1,6 @@
+<section class="excelencia-equidade-banner-ct">
+    <a href="http://www.fundacaolemann.org.br/excelencia-com-equidade/?utm_source=qedu&amp;utm_medium=banner&amp;utm_campaign=divulgacao-excelencia-equidade" target="_blank">
+        <img src="https://qedu-assets.s3.amazonaws.com/banner_excelencia_equidade_mini.jpg"
+             alt="Excelência com Equidade - Os desafios dos anos finais do ensino fundamental - Clique e saiba mais">
+    </a>
+</section>

--- a/app/Resources/views/learning/brazil.html.twig
+++ b/app/Resources/views/learning/brazil.html.twig
@@ -1,0 +1,79 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Aprendizado dos alunos: Brasil - QEdu{% endblock %}
+
+{% block description %}Com base nos resultados da Prova Brasil 2015, é possível calcular a proporção de alunos com aprendizado adequado à sua etapa escolar{% endblock %}
+{% block og_title %}Aprendizado dos alunos: Brasil - QEdu{% endblock %}
+{% block og_description %}Com base nos resultados da Prova Brasil 2015, é possível calcular a proporção de alunos com aprendizado adequado à sua etapa escolar{% endblock %}
+
+{% block stylesheets %}
+  <link type="text/css" href="/gimme/d3e1a7d09b/pkg/css/provabrasil.css" rel="stylesheet">
+  <link type="text/css" href="/gimme/cfdcda464f/pkg/css/provabrasil/dropdown-select2.css" rel="stylesheet"/>
+  <link type="text/css" href="/gimme/c17a152ffb/pkg/css/provabrasil/banner.css" rel="stylesheet"/>
+{% endblock %}
+
+{% block body %}
+  {% include 'learning/subnav.html.twig' %}
+  {% include 'learning/banner.html.twig' %}
+{% endblock %}
+
+{% block javascripts %}
+  <script type="text/javascript" src="/gimme/ddfef5b5e4/pkg/js/mcc-boot.js"></script>
+  <script type="text/javascript" src="/gimme/2a854d73fb/pkg/js/QEdu/Header.js"></script>
+  <script type="text/javascript" src="/gimme/f46964a241/pkg/js/select2-lib.js"></script>
+  <script type="text/javascript" src="/gimme/85d63f33ed/pkg/js/provabrasil/dropdown-select2.js"></script>
+  <script type="text/javascript">
+      mcc.init_behaviors({
+          "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}],
+          "behavior-dropdown-select2": [{
+              "fetch_from": "\/ajax\/dropdown\/remote\/states?url_default=\/aprendizado",
+              "formatSearchingText": "Carregando estados...",
+              "placeholder_input": "Busque por estado...",
+              "formatNoMatches": "Nenhum resultado para \"%s\".",
+              "small_dropdown": true,
+              "pull_right": true,
+              "height": 1,
+              "extra_dropdown_classes": " select2-breadcrumb-box",
+              "initial_selection": "<a class=\"drop-with-text-only\">Ir para um estado <\/a>",
+              "idElement": "ujeid_1"
+          }],
+          "i18n": [{
+              "proficiency.loading": "Carregando filtros...",
+              "proficiency.dependence.0": "p\u00fablica",
+              "proficiency.dependence.1": "federal",
+              "proficiency.dependence.2": "estadual",
+              "proficiency.dependence.3": "municipal"
+          }],
+          "provabrasil-didactic-proficiency-behavior": [{
+              "isSchool": false,
+              "stateMenuConfigs": {
+                  "grade": 5,
+                  "discipline": 1,
+                  "dependence": 0,
+                  "token": "66f488b76d4e448e814189feecf57acbcbb7e050"
+              }
+          }],
+          "Meritt\/QEdu\/UI\/Footer\/Assets\/js\/IdebModal": [[]],
+          "provabrasil-behavior-util-tooltip": [{"all": true}],
+          "provabrasil-behavior-util-popover": [[]],
+          "provabrasil-behavior-util-smoothscroll": [[]],
+          "util-print": [{
+              "modals": {"too_big": "ujeid_3", "not_supported": "ujeid_4"},
+              "token": "66f488b76d4e448e814189feecf57acbcbb7e050",
+              "actionId": 2
+          }],
+          "uservoice-widget": [{
+              "id": "9cybWXvohVkb7CzZ6jGg",
+              "subdomain": "qedu",
+              "user_logged": false,
+              "push": {
+                  "set": {
+                      "accent_color": "#7baa31",
+                      "trigger_color": "white",
+                      "trigger_background_color": "#7baa31"
+                  }, "addTrigger": {"mode": "contact", "trigger_position": "bottom-right"}
+              }
+          }]
+      });
+  </script>
+{% endblock %}

--- a/app/Resources/views/learning/subnav.html.twig
+++ b/app/Resources/views/learning/subnav.html.twig
@@ -1,0 +1,64 @@
+<section class="subnav-section gray-pattern">
+
+  <div class="container with-avatar-small">
+
+    <div class="subnav-title">
+      <ul class="subnav-breadcrumb has-no-parent">
+        <li>
+          <div class="subnav-title brasil-title">
+            <a href="/brasil/aprendizado"><strong>Brasil</strong></a>
+          </div>
+        </li>
+        <li id="ujeid_1-dropdown" class="dropdown ">
+          <div class="select2-container" id="s2id_ujeid_1">
+            <a href="javascript:void(0)" onclick="return false;" class="select2-choice" tabindex="-1">
+              <abbr class="select2-search-choice-close"></abbr>
+              <span class="select2-arrow"><b></b></span>
+            </a>
+            <input class="select2-focusser select2-offscreen" type="text" id="s2id_autogen1">
+            <div class="select2-drop select2-display-none dropdown-limited-height pull-right-select2 small-select2 select2-breadcrumb-box select2-with-searchbox">
+              <div class="select2-search">
+                <input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" class="select2-input">
+              </div>
+              <ul class="select2-results"></ul>
+            </div>
+          </div>
+          <input type="hidden" id="ujeid_1" tabindex="-1" class="select2-offscreen">
+        </li>
+      </ul>
+    </div>
+    <div class="clearfix"></div>
+
+    <div class="block-image thumbnail avatar-block-small ">
+      <a href="/brasil" rel="tooltip" title="" class="avatar-container" data-original-title="">
+        <img src="/img/provabrasil/avatar/states/128px/BR.png">
+      </a>
+    </div>
+
+    <div class="subnav-title">
+      <h1>Brasil</h1>
+    </div>
+
+    <div class="action-buttons social-section">
+      <div class="addthis_sharing_toolbox"></div>
+    </div>
+  </div>
+
+  <div class="subnav with-avatar-small-margin">
+    <ul class="nav nav-pills">
+      <li class="active">
+        <a href="/brasil/aprendizado">Aprendizado</a>
+      </li>
+      <li><a href="/brasil/compare">Compare</a></li>
+      <li><a href="/brasil/evolucao">Evolução</a></li>
+      <li><a href="/brasil/proficiencia">Proficiência</a></li>
+      <li><a href="/brasil/explorar">Explore</a></li>
+      <li><a href="/brasil/pessoas">Pessoas</a></li>
+      <li><a href="/brasil/censo-escolar">Censo</a></li>
+      <li><a href="/brasil/ideb">Ideb</a></li>
+    </ul>
+  </div>
+
+</section>
+
+<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-542c488254cb45ee" async></script>

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class LearningController extends Controller
+{
+    /**
+     * @Route("/brasil/aprendizado-new", name="learning_brazil")
+     */
+    public function brazilAction()
+    {
+        return $this->render('learning/brazil.html.twig');
+    }
+}


### PR DESCRIPTION
## Description

First all, we are going to migrate the static fragments in the url [http://qedu.org.br/brasil/aprendizado](http://qedu.org.br/brasil/aprendizado) from legacy project to qedu-hub.

## Motivation and context
OKR Cycle 3.
> **KR 2.2**: In order to make QEdu Hub ready to receive new features and evolutions, without relying on Portal QEdu's legacy software, we are going to migrate `/brasil/aprendizado`.


 
## Main changes

This PR closes the issues [QHR-19](https://portalqedu.atlassian.net/browse/QHR-19), [QHR-5](https://portalqedu.atlassian.net/browse/QHR-5), [QHR-9](https://portalqedu.atlassian.net/browse/QHR-9), [QHR-17](https://portalqedu.atlassian.net/browse/QHR-17), [QHR-7](https://portalqedu.atlassian.net/browse/QHR-7) and [QHR-50](https://portalqedu.atlassian.net/browse/QHR-50). 

- Add Learning Controller.
- Add html Header.
- Add Top bar.
- Add Sub nav bar.
- Add Equidade banner and footer.
- Add Breadcrumb.
