### PR TITLE
Add filter in Brazil learning page

### DIFF
--- a/app/Resources/views/learning/brazil.html.twig
+++ b/app/Resources/views/learning/brazil.html.twig
@@ -25,7 +25,7 @@
   <script type="text/javascript" src="/gimme/85d63f33ed/pkg/js/provabrasil/dropdown-select2.js"></script>
   <script type="text/javascript" src="/gimme/200fd91df6/pkg/js/provabrasil.js"></script>
   <script type="text/javascript" src="/gimme/e2a780a5ad/pkg/js/mcc-basic-libs.js"></script>
-  <script type="text/javascript" src="/gimme/918af2f000/pkg/js/didactic.js"></script>
+  <script type="text/javascript" src="/gimme/918af2f001/pkg/js/didactic.js"></script>
   <script type="text/javascript" src="/gimme/200fd91df6/pkg/js/jquery.libs.js"></script>
 
   <script type="text/javascript">

--- a/app/Resources/views/learning/brazil.html.twig
+++ b/app/Resources/views/learning/brazil.html.twig
@@ -24,12 +24,17 @@
   <script type="text/javascript" src="/gimme/f46964a241/pkg/js/select2-lib.js"></script>
   <script type="text/javascript" src="/gimme/85d63f33ed/pkg/js/provabrasil/dropdown-select2.js"></script>
   <script type="text/javascript" src="/gimme/200fd91df6/pkg/js/provabrasil.js"></script>
+  <script type="text/javascript" src="/gimme/e2a780a5ad/pkg/js/mcc-basic-libs.js"></script>
   <script type="text/javascript" src="/gimme/918af2f000/pkg/js/didactic.js"></script>
   <script type="text/javascript" src="/gimme/200fd91df6/pkg/js/jquery.libs.js"></script>
 
   <script type="text/javascript">
       mcc.init_behaviors({
-          "Meritt\/QEdu\/UI\/Sentry\/Assets\/js\/SentryBehavior":[{"dsn":"http:\/\/f89464467aa14ba49c5ab771c25b1a96@sentry.qedu.org.br\/2","user":null,"options":{"ignoreErrors":["undefined"]}}],
+          "Meritt\/QEdu\/UI\/Sentry\/Assets\/js\/SentryBehavior": [{
+              "dsn": "http:\/\/f89464467aa14ba49c5ab771c25b1a96@sentry.qedu.org.br\/2",
+              "user": null,
+              "options": {"ignoreErrors": ["undefined"]}
+          }],
           "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}],
           "behavior-dropdown-select2": [{
               "fetch_from": "\/ajax\/dropdown\/remote\/states?url_default=\/aprendizado",
@@ -60,6 +65,8 @@
               }
           }],
           "Meritt\/QEdu\/UI\/Footer\/Assets\/js\/IdebModal": [[]],
+          "provabrasil-behavior-util-tooltip": [{"all": true}],
+          "provabrasil-behavior-util-popover": [[]],
           "provabrasil-behavior-util-smoothscroll": [[]],
           "util-print": [{
               "modals": {"too_big": "ujeid_3", "not_supported": "ujeid_4"},

--- a/app/Resources/views/learning/content.html.twig
+++ b/app/Resources/views/learning/content.html.twig
@@ -26,23 +26,20 @@
 
 <section class="normal-section didactic-section container">
 
-  {#<div class="container-db-filters">#}
-  {#<div class="didactic-block-filters row">#}
-  {#<div class="btn-group db-filters span12">#}
-  {#<ul class="nav first pull-left">#}
-  {#<li class="active">Informações sobre:</li>#}
-  {#</ul>#}
-
-
-  {#<ul class="nav nav-pills pull-left">#}
-  {#<li class="active"><a href="#" data-value="0" data-filter="dependence">Todas</a></li>#}
-  {#<li><a href="#" data-value="3" data-filter="dependence">Escolas Municipais</a></li>#}
-  {#<li><a href="#" data-value="2" data-filter="dependence">Escolas Estaduais</a></li>#}
-  {#</ul>#}
-
-  {#</div>#}
-  {#</div>#}
-  {#</div>#}
+  <div class="container-db-filters">
+    <div class="didactic-block-filters row">
+      <div class="btn-group db-filters span12">
+      <ul class="nav first pull-left">
+        <li class="active">Informações sobre:</li>
+      </ul>
+      <ul class="nav nav-pills pull-left">
+        <li><a href="#" data-value="0" data-filter="dependence">Todas</a></li>
+        <li><a href="#" data-value="3" data-filter="dependence">Escolas Municipais</a></li>
+        <li><a href="#" data-value="2" data-filter="dependence">Escolas Estaduais</a></li>
+      </ul>
+      </div>
+    </div>
+  </div>
 
   <div class="didactic-block row">
     <div class="span7" id="state-100">

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -21,7 +21,7 @@ class LearningController extends Controller
     }
 
     /**
-     * @Route("/brasil/aprendizado-new", name="learning_brazil")
+     * @Route("/brasil/aprendizado", name="learning_brazil")
      */
     public function brazilAction()
     {

--- a/src/AppBundle/Repository/ProficiencyRepository.php
+++ b/src/AppBundle/Repository/ProficiencyRepository.php
@@ -26,6 +26,8 @@ class ProficiencyRepository extends EntityRepository implements ProficiencyRepos
             ->andWhere('dpa.dependenceId = 0')
 
             ->andWhere('dpa.editionId= '.$editionCode)
+            ->addOrderBy('dpa.disciplineId')
+            ->addOrderBy('dpa.gradeId')
             ->getQuery()
             ->getResult();
     }


### PR DESCRIPTION
## Description

Add dependence filter _(which means filter by cities, states and all)_ in Brazil learning page `/brasil/aprendizado`.

## Motivation and context

Finalize a minimum version to promote Brazil learning page to production environment in order to achieve  KR 2.2.

> **KR 2.2**: In order to make QEdu Hub ready to receive new features and evolutions, without relying on Portal QEdu's legacy software, we are going to migrate `/brasil/aprendizado`.

## Main Changes

- Add filter in Brazil learning page.
- Enable popovers in brazil learning page.
- Order Brazilian proficiencies.

## Screenshots 

![screen shot 2017-10-26 at 9 24 39 pm](https://user-images.githubusercontent.com/1117674/32081427-293ecfd6-ba94-11e7-911c-14f24e134f0b.png)
