### PR TITLE
Add New Relic Handler

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -12,8 +12,14 @@ monolog:
         main:
             type: fingers_crossed
             action_level: error
-            handler: nested
-        nested:
+            handler: main_group
+        main_group:
+            type: group
+            members: [ newrelic, main_stream ]
+        newrelic:
+            type: newrelic
+            level: error
+        main_stream:
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug


### PR DESCRIPTION
## Description

Add `New Relic Handler` in production environment to catch application errors.

## Motivation and context

Application errors monitoring through New Relic.

## Main Changes

- Add New Relic Handler.

## Screenshots 

![nr-sf-errors](https://user-images.githubusercontent.com/1117674/32198848-17bd4312-bdb1-11e7-96ac-80fad99a3ef5.png)
