### PR TITLE
Migrate distortion.js

### DIFF
--- a/src/GimmeBundle/Resources/assets/gulpfile.js
+++ b/src/GimmeBundle/Resources/assets/gulpfile.js
@@ -327,9 +327,50 @@ gulp.task('mcc-boot.js', function() {
         './javascript/src/Mcc/Extra/Dev/behavior-reload.js',
         './javascript/src/Mcc/Extra/UserVoice/behavior-uservoice-widget.js'
     ])
-        .pipe(exec(jsUglifyQuotes, execOptions))
-        .pipe(concat('mcc-boot.js', noBreakLineOption))
-        .pipe(gulp.dest('./javascript/dist/'));
+    .pipe(exec(jsUglifyQuotes, execOptions))
+    .pipe(concat('mcc-boot.js', noBreakLineOption))
+    .pipe(gulp.dest('./javascript/dist/'));
+});
+
+gulp.task('distortion.js', function() {
+    return gulp.src([
+        './javascript/src/ProvaBrasil/Distortion/service/ColorScale.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionFilter.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionStatus.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionEvolution.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionEvolutionBrazil.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionEvolutionState.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionEvolutionCity.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionEvolutionSchool.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionEntity.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionBrazil.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionState.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionCity.coffee',
+        './javascript/src/ProvaBrasil/Distortion/models/DistortionSchool.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionEntities.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionStates.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionCities.coffee',
+        './javascript/src/ProvaBrasil/Distortion/collections/DistortionSchools.coffee',
+        './javascript/src/ProvaBrasil/Distortion/routes/DistortionRouter.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionPlayerView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/Filters/DistortionDependenceFilterView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/Filters/DistortionLocalizationFilterView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/Filters/DistortionYearFilterView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionFilterView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionStageView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionEvolutionView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionTableSchoolView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionMapView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/views/DistortionPaneToggleView.coffee',
+        './javascript/src/ProvaBrasil/Distortion/behaviorDistortion.coffee',
+    ])
+    .pipe(concat('distortion.js'))
+    .pipe(gulp.dest('./javascript/dist/'))
+    .pipe(exec(jsCompileCoffee, execOptions))
+    .pipe(gulp.dest('./javascript/dist/'))
+    .pipe(exec(jsUglifyQuotes, execOptions))
+    .pipe(gulp.dest('./javascript/dist/'));
 });
 
 gulp.task('default', [
@@ -342,5 +383,6 @@ gulp.task('default', [
     'landingideb.js',
     'mcc-boot.js',
     'mcc-basic-libs.js',
-    'provabrasil.js'
+    'provabrasil.js',
+    'distortion.js',
 ]);

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionCities.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionCities.coffee
@@ -1,0 +1,6 @@
+DistortionCities = DistortionEntities.extend
+  url: () ->
+    if not @parentModel and __DEV__
+      throw 'You need to set a parent model to load the cities'
+    '/api/distortion/state/'+@parentModel.get('id')+'/cities'
+  model: DistortionCity

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEntities.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEntities.coffee
@@ -1,0 +1,123 @@
+###
+@requires js/backbone.js
+###
+
+DistortionEntities = Backbone.Collection.extend
+  initialize: (models, options) ->
+    _.bindAll @, 'addEvolutionDataToEntity', 'addEvolutionDataToModel', 'getFilter', 'setFilter', 'parse',
+      'setParentModel', 'processQueue', 'continueProcessingQueue', 'fetch'
+    @setParentModel options.parentModel if options and options.parentModel
+    @distortionFilter = new DistortionFilter 2016, 0, 0, 1
+
+    @temporaryDistortionData = {}
+    @on 'add', @addEvolutionDataToEntity
+
+    ###
+      Want to know what are the variables below? See in the DistortionEvolution.coffee file :)
+    ###
+    @filtersUsed = []
+    @filtersQueue = []
+    @actualOptions = null
+    @actualFilter = null
+    @on 'sync', @continueProcessingQueue
+
+  url: () ->
+    if __DEV__
+      throw 'You need to overwrite the method url()'
+
+  model: () ->
+    if __DEV__
+      throw "You need to overwrite the method/attribute model"
+
+  addEvolutionDataToEntity: (model, collection, options) ->
+    @addEvolutionDataToModel model, options['actualFilter']
+
+  addEvolutionDataToModel: (model, filter=@actualFilter) ->
+    if filter not instanceof DistortionFilter
+      filter = @actualFilter
+    if not filter
+      throw "Actual Filter not found (in collection of entities)"
+    idModel = model.get 'id'
+    distortionData = @temporaryDistortionData[idModel]
+    if not distortionData and __DEV__
+      throw "Error in capture of the data of Distortion"
+    distortionModel = new DistortionStatus()
+    distortionModel.set distortionData
+    distortionModel = model.getEvolution().addFilterAttributes distortionModel, filter
+    model.getEvolution().add distortionModel,
+      silent: true
+    delete @temporaryDistortionData[idModel]
+
+  getFilter: () ->
+    if not @distortionFilter and __DEV__
+      throw 'Specify a filter'
+    @distortionFilter
+
+  setFilter: (@distortionFilter) ->
+    if @distortionFilter not instanceof DistortionFilter and __DEV__
+      throw "Filter invalid"
+
+  parse: (modelsData, options) ->
+    allowed_keys = ['id','name','ibge_id']
+    result = []
+    for modelData in modelsData
+      distortionData = _.omit modelData, allowed_keys
+      modelData = _.pick modelData, allowed_keys
+      idModel = modelData['id']
+      @temporaryDistortionData[idModel] = distortionData
+      if model = @get idModel
+        @addEvolutionDataToModel model, options['actualFilter']
+      else
+        modelData['actualFilter'] = options['actualFilter']
+        result.push modelData
+    result
+
+  setParentModel: (@parentModel) ->
+    if @parentModel not instanceof DistortionEntity
+      @parentModel = new DistortionEntity
+        id: @parentModel
+
+  getParentModel: () ->
+    @parentModel
+
+  processQueue: () ->
+    if @actualOptions isnt null
+      #We are waiting a request
+      return
+    else if _.isEmpty @filtersQueue
+      # or we not have a queue to process!
+      @trigger 'queue-done'
+      return
+    @trigger 'queue-started'
+    @actualOptions = @filtersQueue.shift()
+    if not @actualOptions
+      return
+    Backbone.Collection.prototype.fetch.call @, @actualOptions
+
+  continueProcessingQueue: () ->
+    ### There are a filter that is loaded. Here, we continue loading other items, if there exists ###
+    @trigger 'queue-finalizated'
+    @each (model) ->
+      model.getEvolution().removeDuplicates() #Remove duplicates, if it exists
+    @actualOptions = null # There are not requests actually happening
+    @processQueue() # Continue to the next request
+
+  fetch: (options = {}) ->
+    @trigger 'start-sync'
+    filter = @getFilter().clone()
+    urlParams = filter.getURLParamsForEntities()
+    options['actualFilter'] = filter
+    options['data'] = urlParams
+    options['remove'] = false
+    oldSuccess = options['success'] or () ->
+    if _.findWhere @filtersUsed, urlParams
+      @trigger 'sync', @, null, options
+      oldSuccess.call @, @, null, options
+      return
+    options['success'] = (collection, response, options) ->
+      oldSuccess.call this, collection, response, options
+    if _.findWhere @filtersQueue, options
+      return
+    @filtersUsed.push urlParams
+    @filtersQueue.push options
+    @processQueue()

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolution.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolution.coffee
@@ -1,0 +1,117 @@
+###
+@requires js/backbone.js
+###
+
+DistortionEvolution = Backbone.Collection.extend
+  comparator: 'year' #Sort the collection by year as it's used by evolution graph
+  model: DistortionStatus
+
+  initialize: (models, options) ->
+    _.bindAll @, 'addFilterAttributes'
+    @setEntity options.entity if options and options.entity
+    @on 'add', @addFilterAttributes
+    @distortionFilter = new DistortionFilter(2016, 0, 0, 1)
+
+    ###
+    Below exists two arrays that are true love <3
+
+    The first is the filtersUsed: It's simply a 'lock' to don't allow the load of repeated filters that are really loaded
+    The second is the filtersQueue: It's what the name speaks: A queue. When something calls the fetch method, the library
+    puts the filter selected in the queue and load each filter one by one, avoiding duplicated (and simultaneous requests), too
+    ###
+    @filtersUsed = []
+    @filtersQueue = []
+    @actualOptions = null
+    @actualFilter = null
+    @on 'sync', @continueProcessingQueue
+
+  url: () ->
+    if __DEV__
+      throw 'You need to overwrite the method url()'
+
+  setEntity: (@entity) ->
+    if @entity not instanceof DistortionEntity
+      @entity = new DistortionEntity
+        id: @entity
+
+  removeDuplicates: () ->
+    self = @
+    @each (model) ->
+      if self.where(model.toJSON()).length > 1
+        self.remove model
+
+  addFilterAttributes: (status, filter = null) ->
+    if filter not instanceof DistortionFilter
+      filter = @actualFilter
+    if not filter
+      throw "Actual Filter not found (in collection of evolution)"
+    for filterName, filterValue of filter.toJSON()
+      if not status.has(filterName) or not status.get filterName
+        status.set filterName, filterValue
+    return status
+
+  getFilter: () ->
+    if not @distortionFilter and __DEV__
+      throw 'Specify a filter'
+    @distortionFilter
+
+  setFilter: (@distortionFilter) ->
+    if @distortionFilter not instanceof DistortionFilter and __DEV__
+      throw "Filter invalid"
+
+  getSelected: () ->
+    #Creates a clone of this collection, only with the registers that match the filter actually selected
+    @removeDuplicates()
+    result = @clone()
+    result.reset @where _.omit @getFilter().toJSON(), 'year'
+    result.removeDuplicates()
+    result.setFilter @getFilter()
+    result
+
+  processQueue: () ->
+    if @actualOptions isnt null
+      #We are waiting a request
+      return
+    else if _.isEmpty @filtersQueue
+      # or we not have a queue to process!
+      @trigger 'queue-done'
+      return
+    @trigger 'queue-started'
+    @actualOptions = @filtersQueue.shift()
+    if not @actualOptions
+      return
+    @actualFilter = @actualOptions['actualFilter']
+    Backbone.Collection.prototype.fetch.call @, @actualOptions
+
+  continueProcessingQueue: () ->
+    ### There are a filter that is loaded. Here, we continue loading other items, if there exists ###
+    @trigger 'queue-finalizated'
+    @removeDuplicates() #Remove duplicates, if it exists
+    @actualOptions = null # There are not requests actually happening
+    @actualFilter = null
+    @processQueue() # Continue to the next request
+
+  getFiltersUsedAndFiltersQueue: () ->
+    _.union @filtersUsed, _.pick @filtersQueue, 'data'
+
+  fetch: (options = {}) ->
+    @trigger 'start-sync'
+    filter = @getFilter().clone()
+    urlParams = filter.getURLParamsForEvolution()
+    options['data'] = urlParams
+    options['actualFilter'] = filter
+    options['remove'] = false #It not can delete other documents in the collection, as this is a cache
+    oldSuccess = options['success'] or () ->
+    if _.findWhere @filtersUsed, urlParams #Compares all properties and return null if  undefined
+      @trigger 'sync', @, null, options
+      oldSuccess.call this, @, null, options
+      return
+    options['success'] = (collection, response, options) ->
+      oldSuccess.call this, collection, response, options
+    if _.findWhere @filtersQueue, options
+      return
+    @filtersUsed.push urlParams
+    @filtersQueue.push options
+    @processQueue()
+
+

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionBrazil.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionBrazil.coffee
@@ -1,0 +1,3 @@
+DistortionEvolutionBrazil = DistortionEvolution.extend
+  url: () ->
+    '/api/distortion/evolution/brasil'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionCity.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionCity.coffee
@@ -1,0 +1,3 @@
+DistortionEvolutionCity = DistortionEvolution.extend
+  url: () ->
+    '/api/distortion/evolution/city/'+@entity.get("id")

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionSchool.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionSchool.coffee
@@ -1,0 +1,3 @@
+DistortionEvolutionSchool = DistortionEvolution.extend
+  url: () ->
+    '/api/distortion/evolution/school/'+@entity.get("id")

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionState.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionEvolutionState.coffee
@@ -1,0 +1,3 @@
+DistortionEvolutionState = DistortionEvolution.extend
+  url: () ->
+    '/api/distortion/evolution/state/'+@entity.get("id")

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionSchools.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionSchools.coffee
@@ -1,0 +1,6 @@
+DistortionSchools = DistortionEntities.extend
+  url: () ->
+    if not @parentModel and __DEV__
+      throw 'You need to set a parent model to load the cities'
+    '/api/distortion/city/'+@parentModel.get('id')+'/schools'
+  model: DistortionSchool

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionStates.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Collections/DistortionStates.coffee
@@ -1,0 +1,3 @@
+DistortionStates = DistortionEntities.extend
+  url: '/api/distortion/states'
+  model: DistortionState

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionBrazil.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionBrazil.coffee
@@ -1,0 +1,16 @@
+DistortionBrazil = DistortionEntity.extend
+  url: '/api/distortion/brasil'
+
+  collectionEvolution: () ->
+    new DistortionEvolutionBrazil [],
+      entity: @
+
+  getChildren: () ->
+    if not @children
+      @children = new DistortionStates()
+      @children.setParentModel @
+      @children.setFilter @getEvolution().getFilter()
+    @children
+
+  getURL: () ->
+    '/brasil/'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionCity.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionCity.coffee
@@ -1,0 +1,17 @@
+DistortionCity = DistortionEntity.extend
+  url: () ->
+    '/api/distortion/city/'+@get('id')
+  collectionEvolution: () ->
+    new DistortionEvolutionCity  [],
+      entity: @
+  hasMap: () ->
+    false
+  getChildren: () ->
+    if not @children
+      @children = new DistortionSchools()
+      @children.setParentModel @
+      @children.setFilter @getEvolution().getFilter()
+    @children
+
+  getURL: () ->
+    '/cidade/'+@get 'id'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionEntity.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionEntity.coffee
@@ -1,0 +1,99 @@
+DistortionEntity = Backbone.Model.extend
+
+  constructor: () ->
+    @evolution = @collectionEvolution()
+    Backbone.Model.apply @, arguments
+
+  initialize: () ->
+    _.bindAll @, 'getEvolution', 'parse', 'processQueue', 'continueProcessingQueue', 'fetch'
+    ###
+      Want to know what are the variables below? See in the DistortionEvolution.coffee file :)
+    ###
+    @filtersUsed = []
+    @filtersQueue = []
+    @actualOptions = null
+    @actualFilter = null
+    @on 'sync', @continueProcessingQueue
+
+  url: () ->
+    if __DEV__
+      throw "You need to overwrite the method url()"
+
+  defaults: () ->
+      name: ""
+      id: ""
+      ibge_id: ""
+
+  collectionEvolution: () ->
+    throw "You need to overwrite the method collectionEvolution"
+
+  getEvolution: () ->
+    @evolution
+
+  parse: (response, options) ->
+    filter = @actualFilter
+    data = if response then response['data'] else []
+    if options['actualFilter']
+      @actualFilter = filter = options['actualFilter']
+    if not filter
+      throw "Actual Filter not found (in model)"
+    response = _.omit response, 'data'
+    evolution = @getEvolution()
+    for stage, status of data
+      statusModel = new DistortionStatus()
+      statusModel.set status
+      statusModel = evolution.addFilterAttributes statusModel, filter
+      statusModel.set 'stageId', stage
+      evolution.add statusModel,
+        silent: true
+    evolution.removeDuplicates()
+    response
+
+
+  processQueue: () ->
+    if @actualOptions isnt null
+      #We are waiting a request
+      return
+    else if _.isEmpty @filtersQueue
+      # or we not have a queue to process!
+      @trigger 'queue-done'
+      return
+    @trigger 'queue-started'
+    @actualOptions = @filtersQueue.shift() # Get a item from the queue and remove it
+    if not @actualOptions
+      return
+    @actualFilter = @actualOptions['actualFilter']
+    Backbone.Model.prototype.fetch.call @, @actualOptions
+
+  continueProcessingQueue: () ->
+    ### There are a filter that is loaded. Here, we continue loading other items, if there exists ###
+    @trigger 'queue-finalizated'
+    @getEvolution().removeDuplicates() #Remove duplicates, if it exists
+    @actualOptions = null # There are not requests actually happening
+    @actualFilter = null
+    @processQueue() # Continue to the next request
+
+  fetch: (options = {}) ->
+    @trigger 'start-sync'
+    # Clone the model to correct use of the filters (and the queue in this model)
+    filter = @getEvolution().getFilter().clone()
+    urlParams = filter.getURLParamsForGetEntity()
+    options['data'] = urlParams
+    options['actualFilter'] = filter
+    if _.findWhere @filtersUsed, urlParams
+      @trigger 'sync', @, null, options
+      return
+    if _.findWhere @filtersQueue, options
+      return
+    @filtersUsed.push urlParams
+    @filtersQueue.push options
+    @processQueue()
+
+  getChildren: () ->
+    throw 'Overwrite the method getChildren() to use it'
+
+  hasMap: () ->
+    true
+
+  getURL: () ->
+    throw 'Overwrite the method getURL() to use it'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionFilter.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionFilter.coffee
@@ -1,0 +1,21 @@
+DistortionFilter = Backbone.Model.extend
+  defaults:
+    dependence: 0
+    localization: 0
+    stageId: 'initial_years'
+    year: 2016
+
+  getURLParamsForGetEntity: () ->
+    result = @toJSON()
+    _.omit result, 'stageId'
+
+  getURLParamsForEvolution: () ->
+      schoolStage: @get 'stageId'
+      dependence: @get 'dependence'
+      localization: @get 'localization'
+
+  getURLParamsForEntities: () ->
+      schoolStage: @get 'stageId'
+      dependence: @get 'dependence'
+      localization: @get 'localization'
+      year: @get 'year'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionSchool.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionSchool.coffee
@@ -1,0 +1,15 @@
+DistortionSchool = DistortionEntity.extend
+  url: () ->
+    '/api/distortion/school/'+@get('id')
+
+  collectionEvolution: () ->
+    new DistortionEvolutionSchool [],
+      entity: @
+
+  hasMap: () ->
+    false
+  getChildren: () ->
+    throw "There's no children"
+
+  getURL: () ->
+    '/escola/'+@get 'id'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionState.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionState.coffee
@@ -1,0 +1,15 @@
+DistortionState = DistortionEntity.extend
+  url: () ->
+    '/api/distortion/state/'+@get('id')
+  collectionEvolution: () ->
+    new DistortionEvolutionState [],
+      entity: @
+  getChildren: () ->
+    if not @children
+      @children = new DistortionCities()
+      @children.setParentModel @
+      @children.setFilter @getEvolution().getFilter()
+    @children
+
+  getURL: () ->
+    '/estado/'+@get 'id'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionStatus.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Models/DistortionStatus.coffee
@@ -1,0 +1,13 @@
+###
+@requires js/backbone.js
+###
+
+DistortionStatus = Backbone.Model.extend
+  defaults:
+    percent: -1
+    percentRounded: -1
+    message: ""
+    year: null
+    stageId: null
+    localization: null
+    dependence: null

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Routes/DistortionRouter.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Routes/DistortionRouter.coffee
@@ -1,0 +1,82 @@
+###
+  Devido a escolha da equipe em montar a URL usando uma querystring, e devido ao fato do Router do Backbone ter uma issue
+  relacionada ao uso de rotas com querystrings, decidi montar essa classe com o mais básico para o uso de rotas com querystring
+  na página de distorção idade/série.
+
+  Não chega ser muito poderosa, na verdade, apenas implementa captura o reconhecimento da querystring, alterando no filtro conforme
+  necessário.
+
+  Além disso, implementa listeners no modelo de filtro para dar um pushState (se suportado), for selecionado.
+
+  É isso. Opiniões?
+
+  Ass: Fernando
+###
+class DistortionRouter
+
+  constructor: (@filter) ->
+    _.bindAll @, 'navigate', 'updateFilter', 'delegateEvents', 'undelegateEvents', 'enable', 'disable'
+
+
+  hasPushState: () ->
+    Modernizr.history
+
+  navigate: () ->
+    data = @filter.toJSON()
+    queryString = mcc.URI.objectToQueryString data
+    newQueryString = window.location.pathname + '?' + queryString
+    if @hasPushState()
+      window.history.replaceState data, document.title, newQueryString
+      if not _.isEmpty(@getHash())
+        window.location.hash = ""
+    else
+      newQueryString = "#" + queryString
+      window.location.hash = newQueryString
+      if not _.isEmpty(window.location.search)
+        window.location.search = ""
+
+  getHash: (w = window) ->
+    result = w.location.href.match(/#(.*)$/)
+    if result
+      result[1]
+    else
+      ''
+
+  updateFilter: () ->
+    queryString = ""
+    if _.isEmpty(window.location.search)
+      queryString = @getHash()
+    else
+      queryString = window.location.search.substring(1)
+    obj = mcc.URI.queryStringToObject queryString
+    fieldsInInt = ['dependence', 'year', 'localization']
+    for field in fieldsInInt
+      if _.has obj, field
+        try
+          obj[field] = parseInt obj[field]
+        catch e
+          delete obj[field] #Invalid field, the script can ignore
+    @filter.set obj,
+     unset: false
+    @navigate()
+
+  delegateEvents: () ->
+    @filter.on 'change', @navigate
+    if @hasPushState()
+      $(window).on 'popstate', @updateFilter
+    else
+      $(window).on 'hashchange', @updateFilter
+
+  undelegateEvents: () ->
+    @filter.off 'change', @navigate
+    if @hasPushState()
+      $(window).off 'popstate', @updateFilter
+    else
+      $(window).off 'hashchange', @updateFilter
+
+  enable: () ->
+    @delegateEvents()
+    @updateFilter()
+
+  disable: () ->
+    @undelegateEvents()

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Service/ColorScale.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Service/ColorScale.coffee
@@ -1,0 +1,31 @@
+class ColorScale
+  constructor: (@scale) ->
+
+  # @param percent int
+  # @return string
+  getColorByPercent: (percent) ->
+    numberRange = @getNumberRangeByPercent percent
+    @scale[numberRange]['color']
+
+  # @param percent int
+  # @return string
+  getCSSClassByPercent: (percent) ->
+    numberRange = @getNumberRangeByPercent percent
+    return 'distortion-color-scale-'+numberRange
+
+  # @return array
+  getScale: () ->
+    @scale
+
+  # @param percent int
+  # @return string
+  getNumberRangeByPercent: (percent) ->
+    if isNaN parseInt percent
+      throw 'Percent passed is not a valid percentage'
+
+    if percent < 0 or percent > 100
+      throw 'Percent passed is not a valid percentage'
+
+    for index, color of @scale
+      if color['min'] <= percent and color['max'] >= percent
+        return index

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionEvolutionView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionEvolutionView.coffee
@@ -1,0 +1,56 @@
+DistortionEvolutionView = Backbone.View.extend
+  initialize: (@options) ->
+    _.bindAll @, 'render'
+    @evolution = @options['regionalAggregation'].getEvolution()
+    @colorScale = @options['colorScale']
+
+  render: () ->
+    colorScale = @colorScale
+    el = @$el.find '.chart'
+    initial_year = @$el.find '.initial-year'
+    final_year = @$el.find '.final-year'
+    @evolution.on 'sync', (evolution) ->
+      seriesData = evolution.getSelected().map (model) ->
+        y: model.get 'percentRounded'
+        id: model.get 'year'
+        marker:
+          radius: 7
+          fillColor: colorScale.getColorByPercent model.get 'percent'
+      seriesData = _.groupBy seriesData, 'id'
+      seriesData = _.map seriesData, (serieData) ->
+        serieData[0]
+      seriesData = _.sortBy seriesData, 'id'
+      years = _.pluck seriesData, 'id'
+      initial_year.html _.first years
+      final_year.html _.last years
+      el.highcharts
+        legend: false
+        title: false
+        tooltip:
+          crosshairs: true
+          valueDecimals: 0
+          valuePrefix: ""
+          pointFormat: "<b style=\"font-size: 16px;\">{point.y}%</b>"
+          shared: true
+          style:
+            color: "#444"
+            fontSize: "11px"
+            padding: "8px"
+
+        xAxis:
+          categories: years
+
+        yAxis:
+          min: 0
+          max: 100
+          labels:
+            format: "{value}%"
+
+          title:
+            text: false
+
+        series: [
+          name: 'Evolução'
+          data: seriesData
+          color: '#cccccc'
+        ]

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionFilterView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionFilterView.coffee
@@ -1,0 +1,24 @@
+DistortionFilterView = Backbone.View.extend
+
+  initialize: (@options) ->
+    @filter = @options['filter']
+    @regionalAggregation = @options['regionalAggregation']
+    @yearView = new DistortionYearFilterView
+      el: @$el.find('#distortion-filter-year-block').get(0)
+      filter: @filter
+      regionalAggregation: @regionalAggregation
+
+    if @regionalAggregation not instanceof DistortionSchool
+      @dependenceView = new DistortionDependenceFilterView
+        el: @$el.find('#distortion-filter-dependence-block').get(0)
+        filter: @filter
+
+      @localizationView = new DistortionLocalizationFilterView
+        el: @$el.find('#distortion-filter-localization-block').get(0)
+        filter: @filter
+
+  render: () ->
+    @yearView.render()
+    if @regionalAggregation not instanceof DistortionSchool
+      @dependenceView.render()
+      @localizationView.render()

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionMapView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionMapView.coffee
@@ -1,0 +1,160 @@
+DistortionMapView = Backbone.View.extend
+  initialize: (@options) ->
+    _.bindAll @, 'initializePlayer', 'loadSVG', 'adjustWidthAndHeight', 'render', '_tooltipMouseMove',
+      '_tooltipMouseLeave'
+    if @isSupported()
+      @svg = SVG @$el.find('#distortion-map-svg')[0]
+      @loadSVG(@options['rawSVGMap'])
+    @regionalAggregation = @options['regionalAggregation']
+    @filter = @options['filter']
+    @colorScale = @options['colorScale']
+    if @regionalAggregation not instanceof DistortionSchool
+      @initializePlayer()
+
+  isSupported: () ->
+    Modernizr.svg and SVG.supported
+
+  initializePlayer: () ->
+    items = ['2016', '2015','2014', '2013', '2012', '2011', '2010', '2009', '2008', '2007', '2006']
+
+    @player = new DistortionPlayerView
+      el: @$el.find('.distortion-play').get 0
+      items: items
+      filter: @filter
+      filterField: 'year'
+      regionalAggregation: @regionalAggregation.getChildren()
+    yearLabel = @$el.find('#year')
+    @player.on 'play', () ->
+      yearLabel.css
+        'background': '#000'
+        'color': '#fff'
+        'padding': '5px'
+    @player.on 'pause', () ->
+      yearLabel.css
+        'background-color': ''
+        'color': ''
+        'padding': ''
+
+  loadSVG: (content) ->
+    @svg.svg(content)
+    @adjustWidthAndHeight()
+
+  adjustWidthAndHeight: () ->
+    children = @svg.children()
+    viewbox = children[0].viewbox()
+    viewbox.y = 0
+    viewbox.x = 0
+    @svg.viewbox viewbox
+    @svg.size viewbox.width, viewbox.height
+
+    @$el.find('#distortion-map-svg').css('margin-left', (($('#distortion-map-svg').width()-viewbox.width)/2)+'px')
+
+  render: () ->
+    if not @isSupported()
+      @$el.find('.distortion-map-unsupported').removeClass('hide')
+      return
+    self = @
+    @$tooltip = $('<div class="distortion-map-tooltip"></div>').appendTo @$el
+    children = @regionalAggregation.getChildren()
+    filter = @filter
+    el = @$el
+    player = @player
+    colorScale = @colorScale
+    svg = @svg.children()
+    svg = svg[0]
+    yearLabel = el.find('#year')
+
+    #groups SVG child nodes to avoid DOM manipulation (or similar) and allow faster access
+
+    svgChildNodes = {}
+    svg.each (i, svgElements) ->
+      for svgElement in svgElements
+        if not svgElement.node
+          continue
+        key = svgElement.node.id.toString()
+        if not key.match /^\d+$/
+          continue
+        svgChildNodes[key] = svgElement
+    , true
+
+    children.on 'sync', () ->
+      yearLabel.html filter.get 'year'
+      usedIDs = []
+      filterData = filter.toJSON()
+
+      children.each (model) ->
+
+        id = model.get 'id'
+        id = id.toString()
+        ibge_id = model.get 'ibge_id'
+        ibge_id = ibge_id.toString()
+        name = model.get 'name'
+
+        usedIDs.push id
+        usedIDs.push ibge_id
+
+        evolution = model.getEvolution()
+
+        #Filter evolution by filter selected
+        dataValue = evolution.findWhere filterData
+
+        if dataValue
+          #Get data
+          percent = dataValue.get 'percent'
+          percentRounded = dataValue.get 'percentRounded'
+          title = name+' ('+percent+'%)'
+
+          color = colorScale.getColorByPercent percent
+        else
+          title = name+' - Sem dados de distorção idade/série para o filtro selecionado'
+          color = '#ffffff'
+
+        #Get element cached
+        element = svgChildNodes[id] or svgChildNodes[ibge_id]
+
+        if not element
+          #We do not have a element, how we can paint it? R: We can't
+          return
+
+        #Define title
+        element.data 'title', title
+
+        #Add to querystring only parameters that have changed in a determinated moment in the page
+        urlParams = mcc.URI.objectToQueryString filter.changedAttributes() or {}
+        if _.isEmpty urlParams
+          #Why add params if urlParams is empty?
+          element.data 'url', model.getURL()+'/distorcao-idade-serie'
+        else
+          element.data 'url', model.getURL()+'/distorcao-idade-serie?'+urlParams
+        element.style 'cursor', 'pointer'
+
+        element.click () ->
+          window.location.href = this.data 'url'
+        element.mousemove self._tooltipMouseMove, element
+        element.mouseleave self._tooltipMouseLeave, element
+        #Animate and fill color
+        element.animate().fill color
+
+      notUsedElements = _.omit svgChildNodes, usedIDs
+      for id, elementNotUsed of notUsedElements
+        elementNotUsed.animate().fill '#ffffff'
+        elementNotUsed.data 'title', 'Sem dados de distorção idade/série para o filtro selecionado'
+
+  _tooltipMouseMove: (e) ->
+    $el = new SVG.Element e.currentTarget
+    if @$tooltip.html() isnt $el.data 'title'
+      @$tooltip
+      .html($el.data('title')+"<br />Clique para abrir ")
+      .show()
+    @$tooltip
+    .css('left', e.pageX + 10)
+    .css('top', e.pageY + 10)
+
+    $el.style 'stroke-width', 4
+
+  _tooltipMouseLeave: (e) ->
+    $el = new SVG.Element e.currentTarget
+
+    @$tooltip.html('').hide()
+    $el.style 'stroke-width', ''
+

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionPaneToggleView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionPaneToggleView.coffee
@@ -1,0 +1,32 @@
+DistortionPaneToggleView = Backbone.View.extend
+  events:
+    'click': 'toggle'
+  render: () ->
+    if __DEV__ and not @$el.is '.distortion-pane-button'
+      throw 'Invalid button'
+    @paneId = @$el.data 'pane-id'
+    @$pane = jQuery '#'+@paneId
+    @max = parseInt @$pane.find('.distortion-pane').last().data 'pane-index'
+    @activeElement = @$pane.find('.distortion-pane-active')
+    @active = parseInt @activeElement.data 'pane-index'
+
+  getNext: (active = @active) ->
+    next = active + 1
+    if next > @max
+      next = 0
+    return next
+
+  toggle: () ->
+    @activeElement.removeClass 'distortion-pane-active'
+    next = @getNext()
+    @activeElement = @$pane.find '#'+@paneId+'-'+next
+    @activeElement.addClass 'distortion-pane-active'
+    @$el.html @$pane.find('#'+@paneId+'-'+@getNext(next)).data 'pane-title'
+    @active = next
+
+DistortionPaneToggleView.applyToAll = () ->
+  $('.distortion-pane-button').each () ->
+    instance = new DistortionPaneToggleView
+      el: @
+    instance.render()
+    $(@).data 'instance', instance

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionPlayerView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionPlayerView.coffee
@@ -1,0 +1,59 @@
+DistortionPlayerView = Backbone.View.extend
+  events:
+    'click': 'receiveEventFromUI'
+
+  initialize: (@options) ->
+    _.bindAll @, 'receiveEventFromUI', 'animate', 'isPlaying', 'getActualStep', 'play', 'pause'
+    @filterField = @options['filterField']
+    @regionalAggregation = @options['regionalAggregation']
+    @icon = @$el.find('i')
+    @items = @options['items'].reverse() #all the options of the filter
+    @interval = @options['interval'] or 1500 #interval between steps
+    @filter = @options['filter']
+    @playing = false
+    @curIndex = 0
+    window.p = @
+
+  receiveEventFromUI: () ->
+    if @playing
+      @pause()
+    else
+      @play()
+
+  animate: () ->
+    if not @playing or @curIndex == @items.length
+      @pause()
+      return
+    animate = @animate
+    interval = @interval
+    # Wait until all the queue of the regionalAggregation was processed and put a interval to the next item
+    @regionalAggregation.once 'queue-done', () ->
+      setTimeout animate, interval
+    actualItem = @items[@curIndex]
+    ++@curIndex
+    @filter.set @filterField, actualItem
+
+
+  isPlaying: () ->
+    @playing
+
+  getActualStep: () ->
+    @filter.get @filterField
+
+  play: () ->
+    if @playing
+      return
+    @playing = true
+    @icon.removeClass 'icon-play'
+    @icon.addClass 'icon-pause'
+    @curIndex = 0
+    @animate()
+    @trigger 'play'
+
+  pause: () ->
+    if not @playing
+      return
+    @playing = false
+    @icon.removeClass 'icon-pause'
+    @icon.addClass 'icon-play'
+    @trigger 'pause'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionStageView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionStageView.coffee
@@ -1,0 +1,122 @@
+DistortionStageView = Backbone.View.extend
+  events:
+    'click .stageIdItem': 'receiveEventFromUI'
+
+  initialize: (@options) ->
+    _.bindAll @, 'receiveEventFromUI', 'receiveEventFromModel', 'setValue', 'watchFilterAndUpdateStagesValues'
+    @stageIdSelected = @$el.find('.stageIdFilters').parent().find('.active').data 'stageid'
+    @regionalAggregation = @options['regionalAggregation']
+    @colorScale = @options['colorScale']
+    @filter = @options['filter']
+    @filter.on 'change:stageId', @receiveEventFromModel
+    @watchFilterAndUpdateStagesValues()
+    # @$el.append($('<div class="alert data-notification" id="alertPrincipal">Estes dados ainda não foram divulgados. Enquanto isso, você pode ver as informações de outros anos utilizando o filtro acima.</div>'))
+
+    # unless @regionalAggregation.children.length
+    #   @$el.append($('<div class="alert data-notification" id="alertPrincipal">Estes dados ainda não foram divulgados. Enquanto isso, você pode ver as informações dos anos anteriores utilizando o filtro acima.</div>'))
+
+  receiveEventFromUI: (e) ->
+    element = $ e.currentTarget
+    if element.data('disabled')
+      return
+    @setValue element.data 'value'
+
+  receiveEventFromModel: () ->
+    @setValue @filter.get 'stageId'
+
+  setValue: (value) ->
+    if value is @stageIdSelected
+      return
+    @filter.set 'stageId', value
+    activeElement = @$el.find '.active'
+    activeElement.removeClass 'active'
+    activeElement.find('#title').addClass 'hide'
+    activeElement.find('.value i').removeClass 'icon-white'
+    activeElement.attr 'title', activeElement.data 'title-tooltip'
+    activeElement.tooltip()
+
+    element = $ ".stageIdItem[data-value='#{value}']"
+    elementParent = element.parent()
+    elementParent.addClass 'active'
+    element.find('#title').removeClass 'hide'
+    element.find('.value i').addClass 'icon-white'
+    elementParent.tooltip 'destroy'
+    elementParent.removeAttr 'title'
+
+    @stageIdSelected = value
+
+  watchFilterAndUpdateStagesValues: () ->
+    evolution = @regionalAggregation.getEvolution()
+    filter = @filter
+    el = @$el
+    colorScale = @colorScale
+    @regionalAggregation.on 'sync', () ->
+      dataValues = evolution.where filter.getURLParamsForGetEntity()
+      stagesWithData = []
+      for dataValue in dataValues
+        percentRounded = dataValue.get 'percentRounded'
+        percent = dataValue.get 'percent'
+        stageId = dataValue.get 'stageId'
+        stageIdContainer = el.find ".stageIdItem[data-value='#{stageId}']"
+        stageIdContainer.data 'disabled', false
+        stagesWithData.push stageIdContainer.data 'value'
+
+        #Valor do titulo
+        valueStageId = stageIdContainer.find '#percent'
+        valueStageId.text percentRounded
+
+        #Barra de progresso
+        percentBar = stageIdContainer.find '.progress'
+        barCssClass = percentBar.data 'cssclass'
+        percentBar.removeClass barCssClass
+        barCssClass = 'progress-'+colorScale.getCSSClassByPercent percent
+        percentBar.addClass barCssClass
+        percentBar.data 'cssclass', barCssClass
+
+        #Tamanho da barra de progresso
+        progressBar = percentBar.find '.bar'
+        if percentRounded < 50
+          progressBarWidth = percentRounded * 2
+        else
+          progressBarWidth = 100
+        progressBar.css
+          'width': progressBarWidth+'%'
+
+        # Texto de titulo (ou impacto, sei lá)
+        if percent == 0
+          titleText = 'Nenhum aluno com atraso escolar de 2 anos ou mais'
+
+
+        else if percent == 100
+          titleText = 'Todos os alunos em atraso escolar de 2 anos ou mais'
+
+        else
+          titleText = 'De cada 100 alunos, aproximadamente '+percentRounded+' estavam com atraso escolar de 2 anos ou mais'
+
+        titleElement = stageIdContainer.find '#title'
+        titleElement.html titleText
+        stageIdContainer.parent().data 'title-tooltip', titleText+'. Clique para ver mais'
+
+      allStages = el.find('.stageIdItem')
+      elementsThatNotHaveData = allStages.filter () ->
+        stageIdElement = $ @
+        not _.contains stagesWithData, stageIdElement.data 'value'
+      elementsThatHaveData = allStages.filter () ->
+        stageIdElement = $ @
+        _.contains stagesWithData, stageIdElement.data 'value'
+      if allStages.length == elementsThatNotHaveData.length
+        allStages.data('disabled', true).fadeOut()
+        el.find('.nav-header').fadeOut()
+        el.find('#alertPrincipal').remove()
+        # el.append($('<div class="alert data-notification" id="alertPrincipal">Estes dados ainda não foram divulgados. Enquanto isso, você pode ver as informações de outros anos utilizando o filtro acima.</div>'))
+      else
+        el.find('#alertPrincipal').remove()
+        allStages.data('disabled', false).fadeIn()
+        el.find('.nav-header').fadeIn()
+        elementsThatHaveData.data('disabled', false).fadeIn()
+        elementsThatHaveData.find('.alertItem').remove()
+        elementsThatNotHaveData.each () ->
+          $el = $ @
+          $el.fadeOut()
+          $el.data 'disabled', true
+          $el.append $ '<div class="alert alertItem" id="alertPrincipal">Não existem dados de distorção idade série para esta localidade, com os filtros selecionados</div>'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionTableSchoolView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionTableSchoolView.coffee
@@ -1,0 +1,70 @@
+DistortionTableSchoolView = Backbone.View.extend
+  initialize: (@options) ->
+    _.bindAll @, 'render'
+    @filter = @options['filter']
+    @regionalAggregation = @options['regionalAggregation']
+
+  render: () ->
+    children = @regionalAggregation.getChildren()
+    filter = @filter
+    el = @$el
+    templateEl = el.find('#school-row-template')
+    rowTemplate = _.template templateEl.html()
+    templateEl.remove()
+
+    headerEl = el.find('#school-header-template')
+    headerTemplate = headerEl.html()
+    headerEl.remove()
+
+    #groups SVG child nodes to avoid DOM manipulation (or similar) and allow faster access
+
+    children.on 'start-sync', () ->
+      $('body').css 'cursor', 'wait'
+      el.eq(0).mask(); # add a loading mask
+      el.eq(1).mask 'Carregando...' # add a loading mask
+
+    children.on 'sync', () ->
+      ###
+        Nos meus testes, é surpreendentemente mais rápido trabalhar com strings HTML grandes do que com
+        objetos do DOM, por isso, essa foi a escolha tomada para trabalhar com a tabela de escolas em um município.
+        Assim, cidades como São Paulo, por exemplo, tornam-se pelo menos usáveis do ponto de vista da velocidade e
+        da estabilidade do navegador :D
+        Ass: Fernando (@fjorgemota)
+      ###
+
+      el.find('#year').html filter.get 'year'
+
+      filterData = filter.toJSON()
+      html = [headerTemplate]
+      console.time 'tableDOM' if __DEV__
+
+      children.each (model) ->
+        evolution = model.getEvolution()
+
+        #Filter evolution by filter selected
+        dataValue = evolution.findWhere filterData
+
+        if dataValue
+          #Get data
+          percent = dataValue.get 'percentRounded'
+          percent = "#{percent}%"
+          #Add to querystring only parameters that have changed in a determinated moment in the page
+          urlParams = mcc.URI.objectToQueryString filter.changedAttributes() or {}
+          if _.isEmpty urlParams
+            #Why add params if urlParams is empty?
+            url = model.getURL()+'/distorcao-idade-serie'
+          else
+            url = model.getURL()+'/distorcao-idade-serie?'+urlParams
+          html.push rowTemplate
+            name: model.get 'name'
+            percent: percent
+            legend: title
+            url: url
+
+      html = html.join ''
+      if html == headerTemplate
+        html += '<tr colspan="2">Não há escolas para esta etapa</div>'
+      el.find('#schools-container').html "<table class='table table-striped table-bordered table-hover'>#{html}</table>"
+      console.timeEnd 'tableDOM' if __DEV__
+      $('body').css 'cursor', ''
+      el.unmask() # remove the loading mask

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/DistortionView.coffee
@@ -1,0 +1,47 @@
+DistortionView = Backbone.View.extend
+
+  initialize: (@options) ->
+
+    @filter = @options['filter']
+    @regionalAggregation = @options['regionalAggregation']
+    @colorScale = @options['colorScale']
+
+    @filterView = new DistortionFilterView
+      regionalAggregation: @regionalAggregation
+      filter: @filter
+      regionalAggregation: @regionalAggregation
+      el: @$el.find('#distortion-filter-block').get 0
+
+    @gradeView = new DistortionStageView
+      filter: @filter
+      el: @$el.find('#distortion-stage-block').get 0
+      regionalAggregation: @regionalAggregation
+      colorScale: @options['colorScale']
+
+    @evolutionView = new DistortionEvolutionView
+      regionalAggregation: @regionalAggregation
+      filter: @filter
+      colorScale: @colorScale
+      el: @$el.find('#distortion-evolution-block').get 0
+
+    if @regionalAggregation.hasMap() and @options['rawSVGMap']
+      @mapView = new DistortionMapView
+        regionalAggregation: @regionalAggregation
+        el: @$el.find('#distortion-map-block').get 0
+        rawSVGMap: @options['rawSVGMap']
+        colorScale: @colorScale
+        filter: @filter
+    else if @regionalAggregation instanceof DistortionCity
+      @tableSchoolsView = new DistortionTableSchoolView
+        regionalAggregation: @regionalAggregation
+        el: @$el.find('#distortion-schools-block').get 0
+        filter: @filter
+        
+  render: () ->
+    @filterView.render()
+    @gradeView.render()
+    @evolutionView.render()
+    if @regionalAggregation.hasMap()
+      @mapView.render()
+    else if @regionalAggregation instanceof DistortionCity
+      @tableSchoolsView.render()

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/Filters/DistortionDependenceFilterView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/Filters/DistortionDependenceFilterView.coffee
@@ -1,0 +1,34 @@
+DistortionDependenceFilterView = Backbone.View.extend
+  events:
+    'click ul.dropdown-menu > li > a': 'receiveEventFromUI'
+
+  initialize: (@options) ->
+    _.bindAll @, 'receiveEventFromUI', 'receiveEventFromModel', 'setValue', 'render'
+    @active = null
+    @label = @$el.find('#distortion-dependence-value')
+    @filter = @options['filter']
+    @filter.on 'change:dependence', @receiveEventFromModel
+
+  receiveEventFromUI: (e) ->
+    if $(e.currentTarget).parent().is('.disabled')
+        return
+    value = $(e.currentTarget).data 'value'
+    @setValue value
+
+  receiveEventFromModel: () ->
+    value = @filter.get 'dependence'
+    @setValue value
+
+  setValue: (value) ->
+    if @active == value
+      return
+    @active = value
+    @$el.find('.dropdown-menu > li.active').removeClass 'active'
+    elementSelected = @$el.find '.dropdown-menu > li > a[data-value="'+value+'"]'
+    if not elementSelected.parent().is '.disabled'
+      elementSelected.parent().addClass 'active'
+    @label.html elementSelected.html()
+    @filter.set 'dependence', value
+
+  render: () ->
+    @active = @$el.find('.dropdown-menu > li.active').data 'value'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/Filters/DistortionLocalizationFilterView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/Filters/DistortionLocalizationFilterView.coffee
@@ -1,0 +1,34 @@
+DistortionLocalizationFilterView = Backbone.View.extend
+  events:
+    'click .dropdown-menu > li > a': 'receiveEventFromUI'
+
+  initialize: (@options) ->
+    _.bindAll @, 'receiveEventFromUI', 'receiveEventFromModel', 'setValue', 'render'
+    @active = null
+    @label = @$el.find('#distortion-localization-value')
+    @filter = @options['filter']
+    @filter.on 'change:localization', @receiveEventFromModel
+
+  receiveEventFromUI: (e) ->
+    if $(e.currentTarget).parent().is('.disabled')
+      return
+    value = $(e.currentTarget).data 'value'
+    @setValue value
+
+  receiveEventFromModel: () ->
+    value = @filter.get 'localization'
+    @setValue value
+
+  setValue: (value) ->
+    if @active == value
+      return
+    @active = value
+    @$el.find('.dropdown-menu > li.active').removeClass 'active'
+    elementSelected = @$el.find '.dropdown-menu > li > a[data-value="'+value+'"]'
+    if not elementSelected.parent().is '.disabled'
+      elementSelected.parent().addClass 'active'
+    @label.html elementSelected.html()
+    @filter.set 'localization', value
+
+  render: () ->
+    @active = @$el.find('.dropdown-menu > li.active').data 'value'

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/Filters/DistortionYearFilterView.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/Views/Filters/DistortionYearFilterView.coffee
@@ -1,0 +1,35 @@
+DistortionYearFilterView = Backbone.View.extend
+  events:
+    'click .dropdown-menu > li > a': 'receiveEventFromUI'
+  initialize: (@options) ->
+    _.bindAll @, 'receiveEventFromUI', 'receiveEventFromModel', 'setValue', 'render'
+    @active = null
+    @label = @$el.find('#distortion-year-value')
+    @regionalAggregation = @options['regionalAggregation']
+    @filter = @options['filter']
+    @filter.on 'change:year', @receiveEventFromModel
+
+
+  receiveEventFromUI: (e) ->
+    if $(e.currentTarget).parent().is '.disabled'
+      return
+    value = $(e.currentTarget).data 'value'
+    @setValue value
+
+  receiveEventFromModel: () ->
+    value = @filter.get 'year'
+    @setValue value
+
+  setValue: (value) ->
+    if @active == value
+      return
+    @active = value
+    @$el.find('.dropdown-menu > li.active').removeClass 'active'
+    elementSelected = @$el.find '.dropdown-menu > li > a[data-value="'+value+'"]'
+    if not elementSelected.parent().is '.disabled'
+      elementSelected.parent().addClass 'active'
+    @label.html value
+    @filter.set 'year', value
+
+  render: () ->
+    @active = @label.html()

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/behaviorDistortion.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Distortion/behaviorDistortion.coffee
@@ -1,0 +1,59 @@
+###
+@requires js/mcc/core/behavior.js
+          js/svg.js/svg.min.js
+###
+mcc.behavior 'behavior-distortion', (config) ->
+
+  # We need of working pane..Okay? :)
+  DistortionPaneToggleView.applyToAll()
+
+  filter = new DistortionFilter()
+  router = new DistortionRouter filter
+
+
+  switch config.regionalAggregationType
+    when 'country'
+      regionalAggregation = new DistortionBrazil()
+    when 'state'
+      regionalAggregation = new DistortionState()
+    when 'city'
+      regionalAggregation = new DistortionCity()
+    when 'school'
+      regionalAggregation = new DistortionSchool()
+    else
+      throw 'Regional Aggregation '+config.regionalAggregationType+' invalid'
+      return
+
+  if config.regionalAggregationType != 'country'
+    if not config.regionalAggregationId
+      throw 'Regional Aggregation ID not received'
+    regionalAggregation.set 'id', config.regionalAggregationId
+
+  regionalAggregation.getEvolution().setFilter filter
+  colorScale = new ColorScale config.colorScale
+
+  filter.on 'change', () ->
+    regionalAggregation.fetch()
+    if regionalAggregation.hasMap() or regionalAggregation instanceof DistortionCity
+      regionalAggregation.getChildren().fetch()
+    evolution = regionalAggregation.getEvolution()
+    evolution.fetch()
+
+  view = new DistortionView
+    filter: filter
+    colorScale: colorScale
+    regionalAggregation: regionalAggregation
+    rawSVGMap: config.rawSVGMap or null
+    el: $('#distortion-container').get 0
+
+  router.enable()
+  if not filter.changedAttributes() #Only load data if it's not changed at startup
+    evolution = regionalAggregation.getEvolution()
+    evolution.fetch()
+    #Update map
+    if regionalAggregation.hasMap()
+      regionalAggregation.getChildren().fetch()
+  if regionalAggregation instanceof DistortionCity
+    # If it's a city we need to load all the children firstly
+    regionalAggregation.getChildren().fetch()
+  view.render()


### PR DESCRIPTION
## Description

Migrate `distortion.js` from legacy to *QEdu-Hub*.

## Motivation and context

Reduce gimme vulnerabilities and achieve KR 2.3.

> **KR 2.3**: Reduce response time (Portal QEdu's time from offline to online) to five minutes.

## Main Changes

- Add new files.
- Add gulp task to generate `distortion.js`.
