### PR TITLE
Add Cache Control header

### DIFF
--- a/src/GimmeBundle/Util/AssetResponseTrait.php
+++ b/src/GimmeBundle/Util/AssetResponseTrait.php
@@ -26,6 +26,7 @@ trait AssetResponseTrait
 
         $response = new Response($fileContent);
         $response->headers->set('Content-Type', $contentType);
+        $response->setPublic()->setMaxAge(15778463);
 
         return $response;
     }


### PR DESCRIPTION
## Description

Add cache control header in gimme endpoints. *QEdu-Hub*.

## Motivation and context

Reduce gimme vulnerabilities and achieve KR 2.3.

> **KR 2.3**: Reduce response time (Portal QEdu's time from offline to online) to five minutes.

## Main Changes

- Add cache control header in gimme endpoints.
