### PR TITLE
Migrate search event tracking implementation

### DIFF
--- a/src/GimmeBundle/Resources/assets/javascript/src/Header/GlobalSearchView.js
+++ b/src/GimmeBundle/Resources/assets/javascript/src/Header/GlobalSearchView.js
@@ -280,7 +280,10 @@
 
             var eventLabel = categoryPicked + ' - ' + optionPicked;
 
-            ga('send', 'event', 'search', 'suggestion picked', eventLabel);
+            dataLayer.push({
+                'event': 'searchEvent',
+                'suggestionPicked': eventLabel
+            });
         }
     });
 }));


### PR DESCRIPTION
## Description

Migrate search event tracking implementation, use Google Tag Manager instead of Google Analytics directly.

## Motivation and context

Use a different Google Analytics account.

