### PR TITLE
Migrate explore.css

### DIFF
--- a/src/GimmeBundle/Resources/assets/gulpfile.js
+++ b/src/GimmeBundle/Resources/assets/gulpfile.js
@@ -617,12 +617,27 @@ gulp.task('dropdown-select2.js', function() {
     .pipe(gulp.dest('./javascript/dist/'))
 });
 
+gulp.task('explore.css', function() {
+    return gulp.src([
+        './stylesheet/src/ProvaBrasil/explore/explore.less',
+        './stylesheet/src/ProvaBrasil/explore/filters.less',
+        './stylesheet/src/ProvaBrasil/explore/isotope.less',
+        './stylesheet/src/ProvaBrasil/explore/map.less',
+        './stylesheet/src/ProvaBrasil/explore/explore-responsive.less',
+    ])
+    .pipe(concat('explore.css'))
+    .pipe(gulp.dest('./stylesheet/dist/'))
+    .pipe(exec(cssCmdVersionOne, execOptions))
+    .pipe(gulp.dest('./stylesheet/dist/'));
+});
+
 gulp.task('default', [
     'banner.css',
     'dropdown-select2.css',
     'landingideb.css',
     'provabrasil.css',
     'ideb.css',
+    'explore.css',
 
     'print_libs.js',
     'distortion.js',

--- a/src/GimmeBundle/Resources/assets/stylesheet/src/ProvaBrasil/explore/explore-responsive.less
+++ b/src/GimmeBundle/Resources/assets/stylesheet/src/ProvaBrasil/explore/explore-responsive.less
@@ -1,4 +1,4 @@
-@import "css/Mixins.less";
+/* @import "css/Mixins.less"; */
 
 @media (min-width: 1200px) {
 //    .subnav .nav{

--- a/src/GimmeBundle/Resources/assets/stylesheet/src/ProvaBrasil/explore/explore.less
+++ b/src/GimmeBundle/Resources/assets/stylesheet/src/ProvaBrasil/explore/explore.less
@@ -1,7 +1,10 @@
-@import 'css/bootstrap/variables.less';
-@import 'css/provabrasil/variables.less';
-@import 'css/bootstrap/mixins.less';
-@import 'css/provabrasil/mixins.less';
+@import 'generic/css/bootstrap/variables.less';
+@import 'stylesheet/src/ProvaBrasil/variables.less';
+@import 'generic/css/bootstrap/mixins.less';
+/* @import 'css/provabrasil/mixins.less'; */
+@import 'stylesheet/src/Meritt/QEdu/UI/Mixins.less';
+
+
 
 /* EXPLORE VARIABLES */
 @exploreSidebarWidth: 305px;


### PR DESCRIPTION
## Description

Migrate `explore.css` from legacy to *QEdu-Hub*.

## Motivation and context

Reduce gimme vulnerabilities.

## Main Changes

- Add new files.
- Add gulp task to generate `explore.css`.