### PR TITLE
Create school learning backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 sudo: false
 
+services:
+  - mysql
+
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/app/Resources/views/learning/amp/school.html.twig
+++ b/app/Resources/views/learning/amp/school.html.twig
@@ -1,0 +1,42 @@
+<h1>{{ schoolName }}</h1>
+
+<div>
+  {% for learning in schoolLearning  %}
+
+    {% set gradeId = learning.getGradeId() %}
+    {% set disciplineId = learning.getDisciplineId() %}
+
+    <div class="didactic-learning-block proficiency-{{ gradeId }}-{{ disciplineId }} ">
+
+      {% set isPortuguese = disciplineId == '1' %}
+
+      {% set discipline = isPortuguese ? 'Português' : 'Matemática' %}
+
+      <h3>{{ discipline }}, {{ gradeId }}º ano</h3>
+
+      <div>
+        <span>
+          <span class="percent-level">{{ learning.getPercentage() }}</span>%
+        </span>
+      </div>
+
+      <p class="description">
+        É a proporção de alunos que aprenderam o adequado na competência de
+        <span class="competence">
+              {% if isPortuguese %}
+                leitura e interpretação de textos
+              {% else %}
+                resolução de problemas
+              {% endif %}
+            </span> até o <span class="grade">{{ gradeId }}º ano</span>
+        na rede <span class="dependence">pública</span> de ensino.
+      </p>
+
+      <small class="no-partial ">
+        Dos <span class="present_count">{{ learning.getTotalStudents() | number_format(0, ',', '.') }}</span> alunos,
+        <span class="optimal_count">{{ learning.getTotalSuccessfulStudents() | number_format(0, ',', '.') }}</span>
+        demonstraram o aprendizado adequado.
+      </small>
+    </div>
+  {% endfor %}
+</div>

--- a/app/Resources/views/learning/amp/school.html.twig
+++ b/app/Resources/views/learning/amp/school.html.twig
@@ -1,4 +1,4 @@
-<h1>{{ schoolName }}</h1>
+<h1>{{ school.getName() }}</h1>
 
 <div>
   {% for learning in schoolLearning  %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,7 +62,7 @@ doctrine:
                 driver: pdo_mysql
                 host: '%database_host%'
                 port: '%database_port%'
-                dbname: 'waitress_entities'
+                dbname: '%waitress_entities_dbname%'
                 user: '%database_user%'
                 password: '%database_password%'
                 charset: UTF8

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -58,6 +58,15 @@ doctrine:
                 user: '%database_user%'
                 password: '%database_password%'
                 charset: UTF8
+            waitress_entities:
+                driver: pdo_mysql
+                host: '%database_host%'
+                port: '%database_port%'
+                dbname: 'waitress_entities'
+                user: '%database_user%'
+                password: '%database_password%'
+                charset: UTF8
+
     orm:
         default_entity_manager: default
         entity_managers:
@@ -67,6 +76,10 @@ doctrine:
                     AppBundle:  ~
             waitress_dw_prova_brasil:
                 connection: waitress_dw_prova_brasil
+                mappings:
+                    AppBundle:  ~
+            waitress_entities:
+                connection: waitress_entities
                 mappings:
                     AppBundle:  ~
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -54,7 +54,7 @@ doctrine:
                 driver: pdo_mysql
                 host: '%database_host%'
                 port: '%database_port%'
-                dbname: 'waitress_dw_prova_brasil'
+                dbname: '%waitress_dw_prova_brasil_dbname%'
                 user: '%database_user%'
                 password: '%database_password%'
                 charset: UTF8

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,5 +1,6 @@
 imports:
     - { resource: config_dev.yml }
+    - { resource: parameters_test.yml }
 
 framework:
     test: ~

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,6 +10,7 @@ parameters:
     # You should uncomment this if you want to use pdo_sqlite
     #database_path: '%kernel.project_dir%/var/data/data.sqlite'
     waitress_dw_prova_brasil_dbname: waitress_dw_prova_brasil
+    waitress_entities_dbname: waitress_entities
 
     mailer_transport: smtp
     mailer_host: 127.0.0.1

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -9,6 +9,7 @@ parameters:
     database_password: ~
     # You should uncomment this if you want to use pdo_sqlite
     #database_path: '%kernel.project_dir%/var/data/data.sqlite'
+    waitress_dw_prova_brasil_dbname: waitress_dw_prova_brasil
 
     mailer_transport: smtp
     mailer_host: 127.0.0.1

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -1,2 +1,3 @@
 parameters:
     waitress_dw_prova_brasil_dbname: waitress_dw_prova_brasil_test
+    waitress_entities_dbname: waitress_entities_test

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -1,0 +1,2 @@
+parameters:
+    waitress_dw_prova_brasil_dbname: waitress_dw_prova_brasil_test

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "psr-4": {
             "Tests\\Fixture\\": "tests/fixture",
             "Tests\\Functional\\": "tests/functional",
+            "Tests\\Integration\\": "tests/integration",
             "Tests\\Unit\\": "tests/unit"
         },
         "files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -6,6 +6,7 @@ use AppBundle\Learning\LearningService;
 use AppBundle\Learning\ProvaBrasilService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class LearningController extends Controller
 {
@@ -31,6 +32,32 @@ class LearningController extends Controller
         return $this->render('learning/brazil.html.twig', [
             'provaBrasilEdition' => $provaBrasilEdition,
             'brazilLearning' => $brazilLearning,
+        ]);
+    }
+
+    /**
+     * @Route("/amp/escola/{schoolId}-{schoolSlug}/aprendizado",
+     *     name="learning_school",
+     *     requirements={
+     *         "schoolId": "\d+",
+     *         "schoolSlug": ".*"
+     *     }
+     * )
+     */
+    public function schoolAction(int $schoolId)
+    {
+        $schoolName = '';
+        $provaBrasilEdition = $this->provaBrasilService->getLastEdition();
+        $schoolLearning = $this->learningService->getSchoolLearningByEdition($schoolId, $provaBrasilEdition);
+
+        if (count($schoolLearning) === 0) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->render('learning/amp/school.html.twig', [
+            'schoolName' => $schoolName,
+            'provaBrasilEdition' => $provaBrasilEdition,
+            'schoolLearning' => $schoolLearning,
         ]);
     }
 }

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -46,9 +46,9 @@ class LearningController extends Controller
      */
     public function schoolAction(int $schoolId)
     {
-        $schoolName = '';
         $provaBrasilEdition = $this->provaBrasilService->getLastEdition();
         $schoolLearning = $this->learningService->getSchoolLearningByEdition($schoolId, $provaBrasilEdition);
+        $schoolName = $this->getSchoolRepository()->find($schoolId)->getName();
 
         if (count($schoolLearning) === 0) {
             throw new NotFoundHttpException();
@@ -59,5 +59,10 @@ class LearningController extends Controller
             'provaBrasilEdition' => $provaBrasilEdition,
             'schoolLearning' => $schoolLearning,
         ]);
+    }
+
+    private function getSchoolRepository()
+    {
+        return $this->getDoctrine()->getRepository('AppBundle:School', 'waitress_entities');
     }
 }

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -48,14 +48,14 @@ class LearningController extends Controller
     {
         $provaBrasilEdition = $this->provaBrasilService->getLastEdition();
         $schoolLearning = $this->learningService->getSchoolLearningByEdition($schoolId, $provaBrasilEdition);
-        $schoolName = $this->getSchoolRepository()->find($schoolId)->getName();
+        $school = $this->getSchoolRepository()->find($schoolId);
 
         if (count($schoolLearning) === 0) {
             throw new NotFoundHttpException();
         }
 
         return $this->render('learning/amp/school.html.twig', [
-            'schoolName' => $schoolName,
+            'school' => $school,
             'provaBrasilEdition' => $provaBrasilEdition,
             'schoolLearning' => $schoolLearning,
         ]);

--- a/src/AppBundle/Entity/School.php
+++ b/src/AppBundle/Entity/School.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * School
+ *
+ * @ORM\Table(name="school",
+ *     uniqueConstraints={
+ *      @ORM\UniqueConstraint(
+ *          name="ibge",
+ *          columns={"ibge_id"}
+ *     ), @ORM\UniqueConstraint(
+ *          name="enem",
+ *          columns={"id", "city_id", "state_id", "ibge_id"}
+ *     )}, indexes={
+ *      @ORM\Index(name="fk_school_dependence1", columns={"dependence_id"}),
+ *      @ORM\Index(name="fk_school_localization1", columns={"localization_id"}),
+ *      @ORM\Index(name="fk_school_operating_conditions1", columns={"operating_conditions_id"}),
+ *      @ORM\Index(name="name", columns={"name_standard"}),
+ *      @ORM\Index(name="prefix_and_name",columns={"name_prefix", "name_standard"}),
+ *      @ORM\Index(name="fk_school_city1", columns={"city_id"}),
+ *      @ORM\Index(name="fk_school_state1", columns={"state_id"}),
+ *      @ORM\Index(name="fast_search", columns={"state_id", "city_id", "id"}),
+ *      @ORM\Index(name="name_2", columns={"name"}),
+ *      @ORM\Index(name="city_name", columns={"city_id", "name"}),
+ *      @ORM\Index(name="Enem Average", columns={"ibge_id", "state_id", "city_id"})})
+ * @ORM\Entity
+ * @ORM\Entity(repositoryClass="AppBundle\Repository\SchoolRepository")
+ */
+class School
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="ibge_id", type="integer", nullable=false)
+     */
+    private $ibgeId;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", length=120, nullable=false)
+     */
+    private $name;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name_prefix", type="string", length=30, nullable=true)
+     */
+    private $namePrefix;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name_standard", type="string", length=100, nullable=true)
+     */
+    private $nameStandard;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="slug", type="string", length=140, nullable=true)
+     */
+    private $slug;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getIbgeId(): int
+    {
+        return $this->ibgeId;
+    }
+
+    public function setIbgeId(int $ibgeId)
+    {
+        $this->ibgeId = $ibgeId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getNamePrefix(): string
+    {
+        return $this->namePrefix;
+    }
+
+    public function setNamePrefix(string $namePrefix)
+    {
+        $this->namePrefix = $namePrefix;
+    }
+
+    public function getNameStandard(): string
+    {
+        return $this->nameStandard;
+    }
+
+    public function setNameStandard(string $nameStandard)
+    {
+        $this->nameStandard = $nameStandard;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug)
+    {
+        $this->slug = $slug;
+    }
+}

--- a/src/AppBundle/Learning/Learning.php
+++ b/src/AppBundle/Learning/Learning.php
@@ -22,12 +22,12 @@ class Learning
 
     public function getTotalSuccessfulStudents(): int
     {
-        return $this->proficiency->getLevelOptimal();
+        return round($this->proficiency->getLevelOptimal(), 0);
     }
 
     public function getTotalStudents(): int
     {
-        return $this->proficiency->getWithProficiencyWeight();
+        return ceil($this->proficiency->getWithProficiencyWeight());
     }
 
     public function getGradeId(): int

--- a/src/AppBundle/Learning/LearningService.php
+++ b/src/AppBundle/Learning/LearningService.php
@@ -23,4 +23,14 @@ class LearningService
 
         return $this->learningFactory->create($brazilProficiency);
     }
+
+    public function getSchoolLearningByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition): array
+    {
+        $brazilProficiency = $this->proficiencyRepository->findSchoolProficiencyByEdition(
+            $schoolId,
+            $provaBrasilEdition
+        );
+
+        return $this->learningFactory->create($brazilProficiency);
+    }
 }

--- a/src/AppBundle/Learning/LearningService.php
+++ b/src/AppBundle/Learning/LearningService.php
@@ -26,11 +26,11 @@ class LearningService
 
     public function getSchoolLearningByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition): array
     {
-        $brazilProficiency = $this->proficiencyRepository->findSchoolProficiencyByEdition(
+        $schoolProficiency = $this->proficiencyRepository->findSchoolProficiencyByEdition(
             $schoolId,
             $provaBrasilEdition
         );
 
-        return $this->learningFactory->create($brazilProficiency);
+        return $this->learningFactory->create($schoolProficiency);
     }
 }

--- a/src/AppBundle/Repository/ProficiencyRepository.php
+++ b/src/AppBundle/Repository/ProficiencyRepository.php
@@ -31,4 +31,23 @@ class ProficiencyRepository extends EntityRepository implements ProficiencyRepos
             ->getQuery()
             ->getResult();
     }
+
+    public function findSchoolProficiencyByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition)
+    {
+        $queryBuilder = $this->createQueryBuilder('p');
+
+        $editionCode = $provaBrasilEdition->getCode();
+
+        return $queryBuilder
+            ->join(DimRegionalAggregation::class, 'dra', 'WITH', 'p.dimRegionalAggregationId = dra.id')
+            ->andWhere('dra.schoolId = '.$schoolId)
+
+            ->join(DimPoliticAggregation::class, 'dpa', 'WITH', 'p.dimPoliticAggregationId = dpa.id')
+
+            ->andWhere('dpa.editionId = '.$editionCode)
+            ->addOrderBy('dpa.disciplineId')
+            ->addOrderBy('dpa.gradeId')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/AppBundle/Repository/ProficiencyRepositoryInterface.php
+++ b/src/AppBundle/Repository/ProficiencyRepositoryInterface.php
@@ -7,4 +7,5 @@ use AppBundle\Learning\ProvaBrasilEdition;
 interface ProficiencyRepositoryInterface
 {
     public function findBrazilProficiencyByEdition(ProvaBrasilEdition $provaBrasilEdition);
+    public function findSchoolProficiencyByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition);
 }

--- a/src/AppBundle/Repository/SchoolRepository.php
+++ b/src/AppBundle/Repository/SchoolRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AppBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class SchoolRepository extends EntityRepository
+{
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+passthru(sprintf(
+    'php "%s/../bin/console" doctrine:database:create --if-not-exists --quiet --env=test',
+    __DIR__
+));
+
+require __DIR__.'/../vendor/autoload.php';

--- a/tests/fixture/Database/ProficiencyTableFixture.php
+++ b/tests/fixture/Database/ProficiencyTableFixture.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Fixture\Database;
+
+class ProficiencyTableFixture
+{
+    private $entityManager;
+
+    public function createTable($kernel)
+    {
+        $this->createDatabase($kernel);
+
+        $this->loadEntityManager($kernel);
+
+        $this->createProficiencyTable();
+        $this->createDimRegionalAggregationTable();
+        $this->createDimPoliticAggregationTable();
+    }
+
+    public function createDatabase($kernel)
+    {
+        $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getConnection()
+            ->prepare("CREATE DATABASE waitress_dw_prova_brasil_test;")
+            ->execute();
+    }
+
+    public function getEntityManager()
+    {
+        return $this->entityManager;
+    }
+
+    public function dropTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare("DROP DATABASE waitress_dw_prova_brasil_test;")
+            ->execute();
+
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
+
+    private function loadEntityManager($kernel)
+    {
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager('waitress_dw_prova_brasil');
+    }
+
+    public function populateWithBrazilRegister()
+    {
+        $this->createBrazilProficiencyRegister();
+        $this->createBrazilDimRegionalAggregationRegister();
+        $this->createBrazilDimPoliticAggregationRegister();
+    }
+
+    public function populateWithSchoolRegister()
+    {
+        $this->createSchoolProficiencyRegister();
+        $this->createSchoolDimRegionalAggregationRegister();
+        $this->createSchoolDimPoliticAggregationRegister();
+    }
+
+    private function createProficiencyTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+CREATE TABLE `fact_proficiency` (
+  `dim_regional_aggregation_id` mediumint(8) unsigned NOT NULL,
+  `dim_politic_aggregation_id` mediumint(8) unsigned NOT NULL,
+  `partition_state_id` tinyint(3) unsigned NOT NULL,
+  `enrolled` int(10) unsigned NOT NULL,
+  `presents` int(10) unsigned NOT NULL,
+  `with_proficiency` int(11) NOT NULL,
+  `with_proficiency_weight` decimal(10,2) NOT NULL,
+  `average` decimal(5,2) unsigned NOT NULL,
+  `level_quantitative` tinyint(3) unsigned NOT NULL,
+  `level_qualitative` tinyint(3) unsigned NOT NULL,
+  `level_optimal` decimal(10,2) unsigned NOT NULL,
+  `qualitative_0` decimal(10,2) unsigned NOT NULL,
+  `qualitative_1` decimal(10,2) unsigned NOT NULL,
+  `qualitative_2` decimal(10,2) unsigned NOT NULL,
+  `qualitative_3` decimal(10,2) unsigned NOT NULL,
+  `disclosure` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  PRIMARY KEY (`dim_regional_aggregation_id`,`dim_politic_aggregation_id`,`partition_state_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+SQL
+            )->execute();
+    }
+
+    private function createDimRegionalAggregationTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+CREATE TABLE `dim_regional_aggregation` (
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `state_id` tinyint(3) unsigned DEFAULT NULL,
+  `city_id` smallint(5) unsigned DEFAULT NULL,
+  `school_id` mediumint(8) unsigned DEFAULT NULL,
+  `team_id` int(10) unsigned DEFAULT NULL,
+  `city_group_id` smallint(5) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `busca` (`state_id`,`city_id`,`school_id`,`team_id`) USING BTREE,
+  KEY `city_group` (`state_id`,`city_group_id`),
+  KEY `city_group_unique` (`state_id`,`city_group_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+SQL
+            )->execute();
+    }
+
+    private function createDimPoliticAggregationTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+CREATE TABLE `dim_politic_aggregation` (
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `dependence_id` tinyint(4) DEFAULT NULL,
+  `localization_id` tinyint(4) DEFAULT NULL,
+  `edition_id` tinyint(4) DEFAULT NULL,
+  `grade_id` tinyint(4) DEFAULT NULL,
+  `discipline_id` tinyint(4) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `busca` (`dependence_id`,`localization_id`,`edition_id`,`grade_id`,`discipline_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+SQL
+            )->execute();
+    }
+
+    private function createBrazilDimPoliticAggregationRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `dim_politic_aggregation` 
+VALUES
+	(937, 0, 0, 6, 5, 1),
+	(938, 0, 0, 6, 5, 2),
+	(940, 0, 0, 6, 9, 1),
+	(941, 0, 0, 6, 9, 2);
+SQL
+            )->execute();
+    }
+
+    private function createBrazilDimRegionalAggregationRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `dim_regional_aggregation` (`id`, `state_id`, `city_id`, `school_id`, `team_id`, `city_group_id`)
+VALUES
+(1, 100, 0, 0, 0, 0);
+SQL
+            )->execute();
+    }
+
+    private function createBrazilProficiencyRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `fact_proficiency` (
+    `dim_politic_aggregation_id`, 
+    `dim_regional_aggregation_id`, 
+    `with_proficiency_weight`, 
+    `level_optimal`, 
+    `qualitative_0`, 
+    `qualitative_1`, 
+    `qualitative_2`, 
+    `qualitative_3`
+) VALUES
+	(937, 1, 2438249.00, 1225082.10, 360308.55, 852858.35, 812656.05, 412426.06),
+	(940, 1, 2097629.24, 629427.98, 373266.07, 1094935.19, 529791.17, 99636.82),
+	(938, 1, 2438249.00, 943413.08, 515218.34, 979617.59, 676757.03, 266656.04),
+	(941, 1, 2097629.24, 291218.33, 646121.21, 1160289.70, 256269.77, 34948.56);
+SQL
+            )->execute();
+    }
+
+    private function createSchoolDimPoliticAggregationRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `dim_politic_aggregation` 
+VALUES
+	(874, 3, 2, 6, 5, 1),
+	(875, 3, 2, 6, 5, 2),
+	(877, 3, 2, 6, 9, 1),
+	(878, 3, 2, 6, 9, 2);
+SQL
+            )->execute();
+    }
+
+    private function createSchoolDimRegionalAggregationRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `dim_regional_aggregation` (`id`, `state_id`, `city_id`, `school_id`, `team_id`, `city_group_id`)
+VALUES
+	(30945, 113, 1597, 142950, 0, 0);
+SQL
+            )->execute();
+    }
+
+    private function createSchoolProficiencyRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `fact_proficiency` (
+    `dim_politic_aggregation_id`, 
+    `dim_regional_aggregation_id`, 
+    `with_proficiency_weight`, 
+    `level_optimal`, 
+    `qualitative_0`, 
+    `qualitative_1`, 
+    `qualitative_2`, 
+    `qualitative_3`
+) VALUES
+	(874, 30945, 25.02, 7.30, 5.21, 12.51, 4.17, 3.13),
+	(877, 30945, 36.01, 12.19, 3.13, 20.69, 11.19, 1.00),
+	(875, 30945, 25.02, 9.38, 4.17, 11.47, 7.30, 2.09),
+	(878, 30945, 36.01, 1.06, 4.19, 30.76, 1.06, 0.00);
+SQL
+            )->execute();
+    }
+}

--- a/tests/fixture/Database/SchoolTableFixture.php
+++ b/tests/fixture/Database/SchoolTableFixture.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Fixture\Database;
+
+class SchoolTableFixture
+{
+    private $entityManager;
+
+    public function createTable($kernel)
+    {
+        $this->createDatabase($kernel);
+
+        $this->loadEntityManager($kernel);
+
+        $this->createSchoolTable();
+    }
+
+    public function createDatabase($kernel)
+    {
+        $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getConnection()
+            ->prepare("CREATE DATABASE waitress_entities_test;")
+            ->execute();
+    }
+
+    public function getEntityManager()
+    {
+        return $this->entityManager;
+    }
+
+    public function dropTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare("DROP DATABASE waitress_entities_test;")
+            ->execute();
+
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
+
+    private function loadEntityManager($kernel)
+    {
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager('waitress_entities');
+    }
+
+    private function createSchoolTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+CREATE TABLE `school` (
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `city_id` smallint(5) unsigned NOT NULL,
+  `state_id` tinyint(3) unsigned NOT NULL,
+  `ibge_id` int(11) NOT NULL,
+  `is_public` tinyint(1) NOT NULL,
+  `name` varchar(120) NOT NULL,
+  `name_prefix` varchar(30) DEFAULT NULL,
+  `name_standard` varchar(100) DEFAULT NULL,
+  `slug` varchar(140) DEFAULT NULL,
+  `district` varchar(60) DEFAULT NULL,
+  `address` varchar(120) DEFAULT NULL,
+  `address_number` varchar(20) DEFAULT NULL,
+  `address_complement` varchar(30) DEFAULT NULL,
+  `address_cep` char(8) DEFAULT NULL,
+  `ddd` char(2) DEFAULT NULL,
+  `phone` char(8) DEFAULT NULL,
+  `public_phone` char(8) DEFAULT NULL,
+  `email` varchar(120) DEFAULT NULL,
+  `dependence_id` tinyint(3) unsigned NOT NULL,
+  `localization_id` tinyint(3) unsigned NOT NULL,
+  `operating_conditions_id` tinyint(3) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ibge` (`ibge_id`),
+  UNIQUE KEY `enem` (`id`,`city_id`,`state_id`,`ibge_id`),
+  KEY `fk_school_dependence1` (`dependence_id`),
+  KEY `fk_school_localization1` (`localization_id`),
+  KEY `fk_school_operating_conditions1` (`operating_conditions_id`),
+  KEY `name` (`name_standard`(9)),
+  KEY `prefix_and_name` (`name_prefix`,`name_standard`),
+  KEY `fk_school_city1` (`city_id`),
+  KEY `fk_school_state1` (`state_id`),
+  KEY `fast_search` (`state_id`,`city_id`,`id`),
+  KEY `name_2` (`name`),
+  KEY `city_name` (`city_id`,`name`),
+  KEY `Enem Average` (`ibge_id`,`state_id`,`city_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=156486 DEFAULT CHARSET=utf8;
+SQL
+            )->execute();
+    }
+
+    public function populateWithSchoolRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `school`
+VALUES (
+  142950, 
+  1597, 
+  113, 
+  31171166, 
+  1, 
+  'EM FAZENDA AGUAS VERDES', 
+  'EM', 
+  'FAZENDA AGUAS VERDES', 
+  'em-fazenda-aguas-verdes', 
+  NULL, 
+  'FAZ AGUAS VERDES', 
+  '0', 
+  '1', 
+  '37170000', 
+  '35', 
+  '38511660', 
+  NULL, 
+  NULL, 
+  3, 
+  2, 
+  1
+);
+SQL
+            )->execute();
+    }
+}

--- a/tests/functional/AppBundle/Controller/LearningControllerTest.php
+++ b/tests/functional/AppBundle/Controller/LearningControllerTest.php
@@ -18,7 +18,7 @@ class LearningControllerTest extends WebTestCase
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertContains('Português, 9º ano', $crawler->filter('.proficiency-9-1 h3')->text());
         $this->assertContains('34', $crawler->filter('.proficiency-9-1 .percent-level')->text());
-        $this->assertContains('36', $crawler->filter('.proficiency-9-1 .present_count')->text());
+        $this->assertContains('37', $crawler->filter('.proficiency-9-1 .present_count')->text());
         $this->assertContains('12', $crawler->filter('.proficiency-9-1 .optimal_count')->text());
     }
 

--- a/tests/functional/AppBundle/Controller/LearningControllerTest.php
+++ b/tests/functional/AppBundle/Controller/LearningControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Functional\AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Fixture\Database\ProficiencyTableFixture;
+
+class LearningControllerTest extends WebTestCase
+{
+    private $proficiencyTableFixture;
+
+    public function testExistentAMPSchoolPage()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/amp/escola/142950-em-fazenda-aguas-verdes/aprendizado');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertContains('Português, 9º ano', $crawler->filter('.proficiency-9-1 h3')->text());
+        $this->assertContains('34', $crawler->filter('.proficiency-9-1 .percent-level')->text());
+        $this->assertContains('36', $crawler->filter('.proficiency-9-1 .present_count')->text());
+        $this->assertContains('12', $crawler->filter('.proficiency-9-1 .optimal_count')->text());
+    }
+
+    public function testNonExistentAMPSchoolPage()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/escola/9999999-non-existent/aprendizado');
+
+        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+    }
+
+    protected function setUp()
+    {
+        $kernel = self::bootKernel();
+
+        $this->proficiencyTableFixture = new ProficiencyTableFixture();
+        $this->proficiencyTableFixture->createTable($kernel);
+        $this->proficiencyTableFixture->populateWithSchoolRegister();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->proficiencyTableFixture->dropTable();
+    }
+}

--- a/tests/functional/AppBundle/Controller/LearningControllerTest.php
+++ b/tests/functional/AppBundle/Controller/LearningControllerTest.php
@@ -4,10 +4,12 @@ namespace Tests\Functional\AppBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Tests\Fixture\Database\ProficiencyTableFixture;
+use Tests\Fixture\Database\SchoolTableFixture;
 
 class LearningControllerTest extends WebTestCase
 {
     private $proficiencyTableFixture;
+    private $schoolTableFixture;
 
     public function testExistentAMPSchoolPage()
     {
@@ -38,6 +40,10 @@ class LearningControllerTest extends WebTestCase
         $this->proficiencyTableFixture = new ProficiencyTableFixture();
         $this->proficiencyTableFixture->createTable($kernel);
         $this->proficiencyTableFixture->populateWithSchoolRegister();
+
+        $this->schoolTableFixture = new SchoolTableFixture();
+        $this->schoolTableFixture->createTable($kernel);
+        $this->schoolTableFixture->populateWithSchoolRegister();
     }
 
     protected function tearDown()
@@ -45,5 +51,7 @@ class LearningControllerTest extends WebTestCase
         parent::tearDown();
 
         $this->proficiencyTableFixture->dropTable();
+
+        $this->schoolTableFixture->dropTable();
     }
 }

--- a/tests/integration/AppBundle/Repository/ProficiencyRepositoryTest.php
+++ b/tests/integration/AppBundle/Repository/ProficiencyRepositoryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Integration\AppBundle\Repository;
+
+use AppBundle\Entity\Proficiency;
+use AppBundle\Learning\ProvaBrasilEdition;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Fixture\Database\ProficiencyTableFixture;
+use Tests\Fixture\ProficiencyEntityFixture;
+
+class ProficiencyRepositoryTest extends KernelTestCase
+{
+    private $em;
+    private $proficiencyTableFixture;
+
+    public function testFindBrazilProficiencyByEdition()
+    {
+        $this->proficiencyTableFixture->populateWithBrazilRegister();
+
+        $proficiencyExpected = ProficiencyEntityFixture::getProficiency();
+
+        $proficiencies = $this->em
+            ->getRepository(Proficiency::class)
+            ->findBrazilProficiencyByEdition(new ProvaBrasilEdition(6, 2015));
+
+        $this->assertCount(4, $proficiencies);
+        $this->assertEquals(
+            $proficiencyExpected->getWithProficiencyWeight(),
+            $proficiencies[0]->getWithProficiencyWeight()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getLevelOptimal(),
+            $proficiencies[0]->getLevelOptimal()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative0(),
+            $proficiencies[0]->getQualitative0()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative1(),
+            $proficiencies[0]->getQualitative1()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative2(),
+            $proficiencies[0]->getQualitative2()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative3(),
+            $proficiencies[0]->getQualitative3()
+        );
+    }
+
+    public function testFindSchoolProficiencyByEdition()
+    {
+        $this->proficiencyTableFixture->populateWithSchoolRegister();
+
+        $proficiencyExpected = new Proficiency();
+        $proficiencyExpected->setWithProficiencyWeight('25.02');
+        $proficiencyExpected->setLevelOptimal('7.30');
+        $proficiencyExpected->setQualitative0('5.21');
+        $proficiencyExpected->setQualitative1('12.51');
+        $proficiencyExpected->setQualitative2('4.17');
+        $proficiencyExpected->setQualitative3('3.13');
+
+        $schoolId = 142950;
+        $proficiencies = $this->em
+            ->getRepository(Proficiency::class)
+            ->findSchoolProficiencyByEdition($schoolId, new ProvaBrasilEdition(6, 2015));
+
+        $this->assertCount(4, $proficiencies);
+        $this->assertEquals(
+            $proficiencyExpected->getWithProficiencyWeight(),
+            $proficiencies[0]->getWithProficiencyWeight()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getLevelOptimal(),
+            $proficiencies[0]->getLevelOptimal()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative0(),
+            $proficiencies[0]->getQualitative0()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative1(),
+            $proficiencies[0]->getQualitative1()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative2(),
+            $proficiencies[0]->getQualitative2()
+        );
+        $this->assertEquals(
+            $proficiencyExpected->getQualitative3(),
+            $proficiencies[0]->getQualitative3()
+        );
+    }
+
+    protected function setUp()
+    {
+        $kernel = self::bootKernel();
+
+        $this->proficiencyTableFixture = new ProficiencyTableFixture();
+        $this->proficiencyTableFixture->createTable($kernel);
+
+        $this->em = $this->proficiencyTableFixture->getEntityManager();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->proficiencyTableFixture->dropTable();
+    }
+}

--- a/tests/unit/AppBundle/Learning/LearningServiceTest.php
+++ b/tests/unit/AppBundle/Learning/LearningServiceTest.php
@@ -13,7 +13,7 @@ class LearningServiceTest extends TestCase
 {
     public function testGetBrazilLearningByEdition()
     {
-        $proficiencyRepositoryMock = $this->getProficiencyRepositoryMock();
+        $proficiencyRepositoryMock = $this->getProficiencyRepositoryMockInBrazilCase();
         $learningFactoryMock = $this->getLearningFactoryMock();
         $provaBrasilEdition = ProvaBrasilEditionFixture::getProvaBrasilEdition();
 
@@ -25,17 +25,57 @@ class LearningServiceTest extends TestCase
         $this->assertEquals($brazilLearningExpected, $brazilLearning);
     }
 
-    private function getProficiencyRepositoryMock()
+    public function testGetSchoolLearningByEdition()
     {
+        $proficiencyRepositoryMock = $this->getProficiencyRepositoryMockInSchoolCase();
+        $learningFactoryMock = $this->getLearningFactoryMock();
+        $provaBrasilEdition = ProvaBrasilEditionFixture::getProvaBrasilEdition();
+        $schoolId = 12392;
+
+        $learningService = new LearningService($proficiencyRepositoryMock, $learningFactoryMock);
+        $schoolLearning = $learningService->getSchoolLearningByEdition($schoolId, $provaBrasilEdition);
+
+        $schoolLearningExpected = LearningFixture::getLearningCollection();
+
+        $this->assertEquals($schoolLearningExpected, $schoolLearning);
+    }
+
+    private function getProficiencyRepositoryMockInBrazilCase()
+    {
+        $proficiencyRepository = $this->getProficiencyRepositoryMock();
+
         $provaBrasilEdition = ProvaBrasilEditionFixture::getProvaBrasilEdition();
         $proficiencyEntity = ProficiencyEntityFixture::getProficiencyEntities();
-
-        $proficiencyRepository = $this->createMock('AppBundle\Repository\ProficiencyRepositoryInterface');
 
         $proficiencyRepository->expects($this->once())
             ->method('findBrazilProficiencyByEdition')
             ->with($this->equalTo($provaBrasilEdition))
             ->willReturn($proficiencyEntity);
+
+        return $proficiencyRepository;
+    }
+
+    private function getProficiencyRepositoryMockInSchoolCase()
+    {
+        $proficiencyRepository = $this->getProficiencyRepositoryMock();
+
+        $provaBrasilEdition = ProvaBrasilEditionFixture::getProvaBrasilEdition();
+        $proficiencyEntity = ProficiencyEntityFixture::getProficiencyEntities();
+
+        $proficiencyRepository->expects($this->once())
+            ->method('findSchoolProficiencyByEdition')
+            ->with(
+                $this->equalTo(12392),
+                $this->equalTo($provaBrasilEdition)
+            )
+            ->willReturn($proficiencyEntity);
+
+        return $proficiencyRepository;
+    }
+
+    private function getProficiencyRepositoryMock()
+    {
+        $proficiencyRepository = $this->createMock('AppBundle\Repository\ProficiencyRepositoryInterface');
 
         return $proficiencyRepository;
     }


### PR DESCRIPTION
## Description

Create school learning backend for **AMP** pages `/amp/escola/*/aprendizado`.

## Motivation and context

> KR2.1: measure the balance between mobile channel implementation cost and return by implementing AMP's proof-of-concept

## Main Changes

- Update Learning controller and repository.
- Add School entity and repository.
- Add integration and functional tests.

## Screenshots 

![screen shot 2018-02-26 at 4 03 50 pm](https://user-images.githubusercontent.com/1117674/36689625-b690173e-1b0e-11e8-9093-f0bf38665fff.png)
