### PR TITLE
Stylize the amp pages

### DIFF
--- a/app/Resources/views/learning/amp/school.html.twig
+++ b/app/Resources/views/learning/amp/school.html.twig
@@ -5,8 +5,8 @@
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     {% set originalUrl = app.request.uri|replace({'/amp': ''}) %}
-    {% set schoolName = school.getName()|title %}
-    <title>Escola {{ schoolName }} - QEdu</title>
+    {% set schoolName = school.getNameStandard()|title ~ ' (' ~ school.getNamePrefix() ~ ')' %}
+    <title>Escola {{ schoolName }} - Aprendizado - QEdu</title>
     <link rel="canonical" href="{{ originalUrl }}">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
@@ -20,6 +20,68 @@
         ]
       }
     </script>
+    <style amp-custom>
+      /* milligram */
+      *,*:after,*:before{box-sizing:inherit}html{box-sizing:border-box;font-size:62.5%}body{color:#606c76;font-family:'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;font-size:1.6em;font-weight:300;letter-spacing:.01em;line-height:1.6}blockquote{border-left:0.3rem solid #d1d1d1;margin-left:0;margin-right:0;padding:1rem 1.5rem}blockquote *:last-child{margin-bottom:0}.button,button,input[type='button'],input[type='reset'],input[type='submit']{background-color:#9b4dca;border:0.1rem solid #9b4dca;border-radius:.4rem;color:#fff;cursor:pointer;display:inline-block;font-size:1.1rem;font-weight:700;height:3.8rem;letter-spacing:.1rem;line-height:3.8rem;padding:0 3.0rem;text-align:center;text-decoration:none;text-transform:uppercase;white-space:nowrap}.button:focus,.button:hover,button:focus,button:hover,input[type='button']:focus,input[type='button']:hover,input[type='reset']:focus,input[type='reset']:hover,input[type='submit']:focus,input[type='submit']:hover{background-color:#606c76;border-color:#606c76;color:#fff;outline:0}.button[disabled],button[disabled],input[type='button'][disabled],input[type='reset'][disabled],input[type='submit'][disabled]{cursor:default;opacity:.5}.button[disabled]:focus,.button[disabled]:hover,button[disabled]:focus,button[disabled]:hover,input[type='button'][disabled]:focus,input[type='button'][disabled]:hover,input[type='reset'][disabled]:focus,input[type='reset'][disabled]:hover,input[type='submit'][disabled]:focus,input[type='submit'][disabled]:hover{background-color:#9b4dca;border-color:#9b4dca}.button.button-outline,button.button-outline,input[type='button'].button-outline,input[type='reset'].button-outline,input[type='submit'].button-outline{background-color:transparent;color:#9b4dca}.button.button-outline:focus,.button.button-outline:hover,button.button-outline:focus,button.button-outline:hover,input[type='button'].button-outline:focus,input[type='button'].button-outline:hover,input[type='reset'].button-outline:focus,input[type='reset'].button-outline:hover,input[type='submit'].button-outline:focus,input[type='submit'].button-outline:hover{background-color:transparent;border-color:#606c76;color:#606c76}.button.button-outline[disabled]:focus,.button.button-outline[disabled]:hover,button.button-outline[disabled]:focus,button.button-outline[disabled]:hover,input[type='button'].button-outline[disabled]:focus,input[type='button'].button-outline[disabled]:hover,input[type='reset'].button-outline[disabled]:focus,input[type='reset'].button-outline[disabled]:hover,input[type='submit'].button-outline[disabled]:focus,input[type='submit'].button-outline[disabled]:hover{border-color:inherit;color:#9b4dca}.button.button-clear,button.button-clear,input[type='button'].button-clear,input[type='reset'].button-clear,input[type='submit'].button-clear{background-color:transparent;border-color:transparent;color:#9b4dca}.button.button-clear:focus,.button.button-clear:hover,button.button-clear:focus,button.button-clear:hover,input[type='button'].button-clear:focus,input[type='button'].button-clear:hover,input[type='reset'].button-clear:focus,input[type='reset'].button-clear:hover,input[type='submit'].button-clear:focus,input[type='submit'].button-clear:hover{background-color:transparent;border-color:transparent;color:#606c76}.button.button-clear[disabled]:focus,.button.button-clear[disabled]:hover,button.button-clear[disabled]:focus,button.button-clear[disabled]:hover,input[type='button'].button-clear[disabled]:focus,input[type='button'].button-clear[disabled]:hover,input[type='reset'].button-clear[disabled]:focus,input[type='reset'].button-clear[disabled]:hover,input[type='submit'].button-clear[disabled]:focus,input[type='submit'].button-clear[disabled]:hover{color:#9b4dca}code{background:#f4f5f6;border-radius:.4rem;font-size:86%;margin:0 .2rem;padding:.2rem .5rem;white-space:nowrap}pre{background:#f4f5f6;border-left:0.3rem solid #9b4dca;overflow-y:hidden}pre>code{border-radius:0;display:block;padding:1rem 1.5rem;white-space:pre}hr{border:0;border-top:0.1rem solid #f4f5f6;margin:3.0rem 0}input[type='email'],input[type='number'],input[type='password'],input[type='search'],input[type='tel'],input[type='text'],input[type='url'],textarea,select{-webkit-appearance:none;-moz-appearance:none;appearance:none;background-color:transparent;border:0.1rem solid #d1d1d1;border-radius:.4rem;box-shadow:none;box-sizing:inherit;height:3.8rem;padding:.6rem 1.0rem;width:100%}input[type='email']:focus,input[type='number']:focus,input[type='password']:focus,input[type='search']:focus,input[type='tel']:focus,input[type='text']:focus,input[type='url']:focus,textarea:focus,select:focus{border-color:#9b4dca;outline:0}select{background:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="#d1d1d1" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>') center right no-repeat;padding-right:3.0rem}select:focus{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="#9b4dca" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')}textarea{min-height:6.5rem}label,legend{display:block;font-size:1.6rem;font-weight:700;margin-bottom:.5rem}fieldset{border-width:0;padding:0}input[type='checkbox'],input[type='radio']{display:inline}.label-inline{display:inline-block;font-weight:normal;margin-left:.5rem}.container{margin:0 auto;max-width:112.0rem;padding:0 2.0rem;position:relative;width:100%}.row{display:flex;flex-direction:column;padding:0;width:100%}.row.row-no-padding{padding:0}.row.row-no-padding>.column{padding:0}.row.row-wrap{flex-wrap:wrap}.row.row-top{align-items:flex-start}.row.row-bottom{align-items:flex-end}.row.row-center{align-items:center}.row.row-stretch{align-items:stretch}.row.row-baseline{align-items:baseline}.row .column{display:block;flex:1 1 auto;margin-left:0;max-width:100%;width:100%}.row .column.column-offset-10{margin-left:10%}.row .column.column-offset-20{margin-left:20%}.row .column.column-offset-25{margin-left:25%}.row .column.column-offset-33,.row .column.column-offset-34{margin-left:33.3333%}.row .column.column-offset-50{margin-left:50%}.row .column.column-offset-66,.row .column.column-offset-67{margin-left:66.6666%}.row .column.column-offset-75{margin-left:75%}.row .column.column-offset-80{margin-left:80%}.row .column.column-offset-90{margin-left:90%}.row .column.column-10{flex:0 0 10%;max-width:10%}.row .column.column-20{flex:0 0 20%;max-width:20%}.row .column.column-25{flex:0 0 25%;max-width:25%}.row .column.column-33,.row .column.column-34{flex:0 0 33.3333%;max-width:33.3333%}.row .column.column-40{flex:0 0 40%;max-width:40%}.row .column.column-50{flex:0 0 50%;max-width:50%}.row .column.column-60{flex:0 0 60%;max-width:60%}.row .column.column-66,.row .column.column-67{flex:0 0 66.6666%;max-width:66.6666%}.row .column.column-75{flex:0 0 75%;max-width:75%}.row .column.column-80{flex:0 0 80%;max-width:80%}.row .column.column-90{flex:0 0 90%;max-width:90%}.row .column .column-top{align-self:flex-start}.row .column .column-bottom{align-self:flex-end}.row .column .column-center{-ms-grid-row-align:center;align-self:center}@media (min-width: 40rem){.row{flex-direction:row;margin-left:-1.0rem;width:calc(100% + 2.0rem)}.row .column{margin-bottom:inherit;padding:0 1.0rem}}a{color:#9b4dca;text-decoration:none}a:focus,a:hover{color:#606c76}dl,ol,ul{list-style:none;margin-top:0;padding-left:0}dl dl,dl ol,dl ul,ol dl,ol ol,ol ul,ul dl,ul ol,ul ul{font-size:90%;margin:1.5rem 0 1.5rem 3.0rem}ol{list-style:decimal inside}ul{list-style:circle inside}.button,button,dd,dt,li{margin-bottom:1.0rem}fieldset,input,select,textarea{margin-bottom:1.5rem}blockquote,dl,figure,form,ol,p,pre,table,ul{margin-bottom:2.5rem}table{border-spacing:0;width:100%}td,th{border-bottom:0.1rem solid #e1e1e1;padding:1.2rem 1.5rem;text-align:left}td:first-child,th:first-child{padding-left:0}td:last-child,th:last-child{padding-right:0}b,strong{font-weight:bold}p{margin-top:0}h1,h2,h3,h4,h5,h6{font-weight:300;letter-spacing:-.1rem;margin-bottom:2.0rem;margin-top:0}h1{font-size:4.6rem;line-height:1.2}h2{font-size:3.6rem;line-height:1.25}h3{font-size:2.8rem;line-height:1.3}h4{font-size:2.2rem;letter-spacing:-.08rem;line-height:1.35}h5{font-size:1.8rem;letter-spacing:-.05rem;line-height:1.5}h6{font-size:1.6rem;letter-spacing:0;line-height:1.4}img{max-width:100%}.clearfix:after{clear:both;content:' ';display:table}.float-left{float:left}.float-right{float:right}
+      /* custom */
+      header {
+        box-shadow: 0px 0px 22px black;
+        width: 100%;
+        min-height: 3rem;
+      }
+      .logo {
+        margin: 10px;
+      }
+      .button {
+        background-color: rgb(139, 195, 74);
+        border-color: rgb(139, 195, 74);
+        float: right;
+        margin: 10px;
+      }
+      a#original-page{
+        color: white;
+      }
+      .school-name {
+        padding-top: 35px;
+      }
+      .didactic-learning-block {
+        box-shadow: 0px 0px 11px black;
+        margin-bottom: 20px;
+        display: -webkit-flex;
+        -webkit-flex-flow: row;
+        flex-flow: row;
+      }
+      .percent-box {
+        color: black;
+        text-overline-color: black;
+        font-size: 2em;
+        -webkit-flex: 1 6 20%;
+        flex: 1 6 20%;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        -webkit-justify-content: center;
+        -ms-flex-pack: center;
+        justify-content: center;
+        -webkit-align-items: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+      .info-box {
+        padding: 10px;
+        padding-left: 20px;
+        -webkit-flex: 3 1 60%;
+        flex: 3 1 60%;
+
+      }
+      footer {
+        border-top: 1px solid;
+      }
+      a:active, a:visited, a:hover {
+        color: green;
+      }
+      .optimal-decile-bg-0{background:#f00}.optimal-decile-bg-1{background:#f60}.optimal-decile-bg-2{background:#fc9700}.optimal-decile-bg-3{background:#fcc115}.optimal-decile-bg-4{background:#fde51f}.optimal-decile-bg-5{background:#f6fd2c}.optimal-decile-bg-6{background:#c9de26}.optimal-decile-bg-7{background:#87cc1d}.optimal-decile-bg-8{background:#63b916}.optimal-decile-bg-9{background:#3ea50f}.optimal-decile-bg-10{background:#3ea50f}
+    </style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   </head>
   <body>
@@ -48,10 +110,18 @@
       </script>
     </amp-analytics>
 
-    <a id="original-page" href="{{ originalUrl }}">Ir para o site</a>
-    <h1>{{ schoolName }}</h1>
+    <header>
+      <amp-img class="logo" src="http://d2jaknbl34vcit.cloudfront.net/img/qedu/header/qedu-logo.png" alt="QEdu" height="28" width="85"></amp-img>
+      <a id="original-page" class="button" href="{{ originalUrl }}">Ir para o site</a>
+    </header>
 
-    <div>
+    <div class="container">
+
+      <h1 class="school-name">{{ schoolName }}</h1>
+
+      <h3>Aprendizado dos alunos na escola</h3>
+      <p>Com base nos resultados da Prova Brasil {{ provaBrasilEdition.getYear() }}, é possível calcular a proporção de alunos com aprendizado adequado à sua etapa escolar.</p>
+
       {% for learning in schoolLearning  %}
 
         {% set gradeId = learning.getGradeId() %}
@@ -63,33 +133,43 @@
 
           {% set discipline = isPortuguese ? 'Português' : 'Matemática' %}
 
-          <h3>{{ discipline }}, {{ gradeId }}º ano</h3>
-
-          <div>
-          <span>
-            <span class="percent-level">{{ learning.getPercentage() }}</span>%
-          </span>
+          <div class="percent-box {{ learning.getPercentage()|proficiencyCssClass }}">
+            <span class="percent-level">
+              {{ learning.getPercentage() }}%
+            </span>
           </div>
 
-          <p class="description">
-            É a proporção de alunos que aprenderam o adequado na competência de
-            <span class="competence">
-                {% if isPortuguese %}
-                  leitura e interpretação de textos
-                {% else %}
-                  resolução de problemas
-                {% endif %}
-            </span> até o <span class="grade">{{ gradeId }}º ano</span>
-            na rede <span class="dependence">pública</span> de ensino.
-          </p>
+          <div class="info-box">
+            <h3>{{ discipline }}, {{ gradeId }}º ano</h3>
 
-          <small class="no-partial ">
-            Dos <span class="present_count">{{ learning.getTotalStudents() | number_format(0, ',', '.') }}</span> alunos,
-            <span class="optimal_count">{{ learning.getTotalSuccessfulStudents() | number_format(0, ',', '.') }}</span>
-            demonstraram o aprendizado adequado.
-          </small>
+            <p class="description">
+              É a proporção de alunos que aprenderam o adequado na competência de
+              <span class="competence">
+                  {% if isPortuguese %}
+                    leitura e interpretação de textos
+                  {% else %}
+                    resolução de problemas
+                  {% endif %}
+              </span> até o <span class="grade">{{ gradeId }}º ano</span>
+              na rede <span class="dependence">pública</span> de ensino.
+            </p>
+
+            <small class="no-partial">
+              Dos <span class="present_count">{{ learning.getTotalStudents() | number_format(0, ',', '.') }}</span> alunos,
+              <span class="optimal_count">{{ learning.getTotalSuccessfulStudents() | number_format(0, ',', '.') }}</span>
+              demonstraram o aprendizado adequado.
+            </small>
+          </div>
         </div>
       {% endfor %}
+      <div>
+        <h4>Referência</h4>
+
+        <p>Setenta por cento (<b>70%</b>) é a proporção de alunos que deve aprender o adequado até 2022, segundo o movimento <a href="http://www.todospelaeducacao.org.br/">Todos Pela Educação</a>.
+
+          Essa classificação não é oficial.</p>
+      </div>
+      <footer>© {{ "now"|date("Y") }} QEdu: Use dados. Transforme a educação.</footer>
     </div>
   </body>
 </html>

--- a/app/Resources/views/learning/amp/school.html.twig
+++ b/app/Resources/views/learning/amp/school.html.twig
@@ -5,19 +5,22 @@
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     {% set originalUrl = app.request.uri|replace({'/amp': ''}) %}
-    {% set schoolName = school.getNameStandard()|title ~ ' ' ~ school.getNamePrefix() %}
-    <title>Escola {{ schoolName }} - Aprendizado - QEdu</title>
+
+    {% set schoolPrefix = school.getNamePrefix() == 'ESCOLA' or school.getNamePrefix() == 'COLEGIO' ? school.getNamePrefix()|title : school.getNamePrefix() %}
+    {% set schoolName =  schoolPrefix ~ ' ' ~ school.getNameStandard()|title %}
+    <title>{{ schoolName }} - Aprendizado - QEdu</title>
     <link rel="canonical" href="{{ originalUrl }}">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
         "@context": "http://schema.org",
         "@type": "NewsArticle",
-        "headline": "Escola {{ schoolName }}",
+        "headline": "{{ schoolName }} - Aprendizado - QEdu",
         "datePublished": "2018-02-27T00:00:00Z",
         "image": [
           "http://qedu.org.br/img/provabrasil/qedu_opengraph_logo.png"
-        ]
+        ],
+        "description": "Com base nos resultados da Prova Brasil {{ provaBrasilEdition.getYear() }}, é possível calcular a proporção de alunos com aprendizado adequado à sua etapa escolar."
       }
     </script>
     <style amp-custom>
@@ -28,6 +31,9 @@
         box-shadow: 0px 0px 22px black;
         width: 100%;
         min-height: 3rem;
+      }
+      h1 {
+        font-size: 12vw;
       }
       .logo {
         margin: 10px;
@@ -42,7 +48,7 @@
         color: white;
       }
       .school-name {
-        padding-top: 35px;
+        padding-top: 25px;
       }
       .didactic-learning-block {
         box-shadow: 0px 0px 11px black;
@@ -68,16 +74,14 @@
         align-items: center;
       }
       .info-box {
-        padding: 10px;
-        padding-left: 20px;
+        padding: 0.8rem;
         -webkit-flex: 3 1 60%;
         flex: 3 1 60%;
-
       }
       footer {
         border-top: 1px solid;
       }
-      a:active, a:visited, a:hover {
+      a, a:active, a:visited, a:hover {
         color: green;
       }
       .optimal-decile-bg-0{background:#f00}.optimal-decile-bg-1{background:#f60}.optimal-decile-bg-2{background:#fc9700}.optimal-decile-bg-3{background:#fcc115}.optimal-decile-bg-4{background:#fde51f}.optimal-decile-bg-5{background:#f6fd2c}.optimal-decile-bg-6{background:#c9de26}.optimal-decile-bg-7{background:#87cc1d}.optimal-decile-bg-8{background:#63b916}.optimal-decile-bg-9{background:#3ea50f}.optimal-decile-bg-10{background:#3ea50f}
@@ -117,10 +121,10 @@
 
     <div class="container">
 
-      <h1 class="school-name">{{ schoolName }}</h1>
+      <h1 class="school-name">{{ school.getNameStandard()|title }}</h1>
 
-      <h3>Aprendizado dos alunos na escola</h3>
-      <p>Com base nos resultados da Prova Brasil {{ provaBrasilEdition.getYear() }}, é possível calcular a proporção de alunos com aprendizado adequado à sua etapa escolar.</p>
+      <h3>Aprendizado dos alunos</h3>
+      <p>Com base na Prova Brasil {{ provaBrasilEdition.getYear() }}, é possível calcular a proporção de alunos com aprendizado adequado.</p>
 
       {% for learning in schoolLearning  %}
 

--- a/app/Resources/views/learning/amp/school.html.twig
+++ b/app/Resources/views/learning/amp/school.html.twig
@@ -5,7 +5,7 @@
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     {% set originalUrl = app.request.uri|replace({'/amp': ''}) %}
-    {% set schoolName = school.getNameStandard()|title ~ ' (' ~ school.getNamePrefix() ~ ')' %}
+    {% set schoolName = school.getNameStandard()|title ~ ' ' ~ school.getNamePrefix() %}
     <title>Escola {{ schoolName }} - Aprendizado - QEdu</title>
     <link rel="canonical" href="{{ originalUrl }}">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/src/AppBundle/Util/Filter/ProficiencyCssClass.php
+++ b/src/AppBundle/Util/Filter/ProficiencyCssClass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AppBundle\Util\Filter;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class ProficiencyCssClass extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('proficiencyCssClass', [$this, 'proficiencyCssClassFilter']),
+        ];
+    }
+
+    public function proficiencyCssClassFilter($percentage)
+    {
+        if ($percentage == 0) {
+            return $this->getCssClass('0');
+        }
+
+        if ($percentage == 100) {
+            return $this->getCssClass('10');
+        }
+
+        if ($percentage < 10) {
+            return $this->getCssClass('1');
+        }
+
+        return $this->getCssClass(mb_substr($percentage, 0, 1));
+    }
+
+    private function getCssClass($percentage)
+    {
+        return sprintf('optimal-decile-bg-%s', $percentage);
+    }
+}

--- a/tests/unit/AppBundle/Util/Filter/ProficiencyCssClassTest.php
+++ b/tests/unit/AppBundle/Util/Filter/ProficiencyCssClassTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\AppBundle\Util\Filter;
+
+use AppBundle\Util\Filter\ProficiencyCssClass;
+use PHPUnit\Framework\TestCase;
+
+class ProficiencyCssClassTest extends TestCase
+{
+    public function testClassShouldBeInstanceOfAbstractExtension()
+    {
+        $proficiencyCssClass = new ProficiencyCssClass();
+
+        $this->assertInstanceOf('Twig\Extension\AbstractExtension', $proficiencyCssClass);
+    }
+
+    /**
+     * @dataProvider proficiencyCssClassDataProvider
+     */
+    public function testProficiencyCssClassFilter($percentage, $cssClassExpected)
+    {
+        $proficiencyCssClass = new ProficiencyCssClass();
+        $cssClass = $proficiencyCssClass->proficiencyCssClassFilter($percentage);
+
+        $this->assertEquals($cssClassExpected, $cssClass);
+    }
+
+    public function proficiencyCssClassDataProvider()
+    {
+        return [
+            [
+                'percentage' => 0,
+                'cssClassExpected' => 'optimal-decile-bg-0'
+            ],
+            [
+                'percentage' => 4,
+                'cssClassExpected' => 'optimal-decile-bg-1'
+            ],
+            [
+                'percentage' => 7,
+                'cssClassExpected' => 'optimal-decile-bg-1'
+            ],
+            [
+                'percentage' => 23,
+                'cssClassExpected' => 'optimal-decile-bg-2'
+            ],
+            [
+                'percentage' => 78,
+                'cssClassExpected' => 'optimal-decile-bg-7'
+            ],
+            [
+                'percentage' => 93,
+                'cssClassExpected' => 'optimal-decile-bg-9'
+            ],
+            [
+                'percentage' => 100,
+                'cssClassExpected' => 'optimal-decile-bg-10'
+            ],
+        ];
+    }
+
+    public function testGetFiltersShouldReturnTwigFilter()
+    {
+        $proficiencyCssClass = new ProficiencyCssClass();
+        $filter = $proficiencyCssClass->getFilters()[0];
+
+        $callable = $filter->getCallable();
+
+        $this->assertEquals('proficiencyCssClass', $filter->getName());
+        $this->assertEquals('proficiencyCssClassFilter', $callable[1]);
+        $this->assertInstanceOf('AppBundle\Util\Filter\ProficiencyCssClass', $callable[0]);
+    }
+}


### PR DESCRIPTION
## Description

Stylize the amp pages.

## Motivation and context

> KR2.1: measure the balance between mobile channel implementation cost and return by implementing AMP's proof-of-concept

## Main Changes

- Create a custom CSS in the amp pages.

## Screenshots

<img width="242" alt="screen shot 2018-03-05 at 5 13 00 pm" src="https://user-images.githubusercontent.com/1117674/36997512-a5392400-2098-11e8-90ce-aca79f1c7a81.png">
