### PR TITLE
Add GTM tracking in Depencency filters

### DIFF
--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Didactic/Compare/view-filters-compare.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Didactic/Compare/view-filters-compare.coffee
@@ -7,7 +7,7 @@
  * Quando for uma página de escola, gerencia o bloco de escola
  * quando for de município, o bloco do município dono da página
  * e assim por diante...
- * 
+ *
  * Este bloco engloba também o filtro seletor.
 ###
 ViewFiltersCompare = Backbone.View.extend
@@ -18,8 +18,8 @@ ViewFiltersCompare = Backbone.View.extend
   statemenu: null
 
   events:
-    'click .nav-pills li a' : 'clickDimensionFilter'    
-  
+    'click .nav-pills li a' : 'clickDimensionFilter'
+
   initialize: (@options) ->
     @statemenu = new StateMenu @options.stateMenuConfigs
 
@@ -58,3 +58,9 @@ ViewFiltersCompare = Backbone.View.extend
     filter = el.attr 'data-filter'
     value = el.attr 'data-value'
     @set filter, value
+    dataLayer.push({
+      'event': 'dependencyFilterTrigger',
+      'dependencyFilterActionVariable': 'clicked Depdendency Filter',
+      'dependencyFilterValueVariable': el['0'].innerText,
+      'dependencyFilterLocationVariable': window.location.href
+    })

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Didactic/Evolution/view-filters-evolution.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Didactic/Evolution/view-filters-evolution.coffee
@@ -3,7 +3,7 @@
  * Quando for uma página de escola, gerencia o bloco de escola
  * quando for de município, o bloco do município dono da página
  * e assim por diante...
- * 
+ *
  * Este bloco engloba também o filtro seletor.
 ###
 ViewFiltersEvolution = Backbone.View.extend
@@ -14,8 +14,8 @@ ViewFiltersEvolution = Backbone.View.extend
   statemenu: null
 
   events:
-    'click .nav-pills li a' : 'clickDimensionFilter'    
-  
+    'click .nav-pills li a' : 'clickDimensionFilter'
+
   initialize: (@options) ->
     @statemenu = new StateMenu @options.stateMenuConfigs
 
@@ -23,7 +23,7 @@ ViewFiltersEvolution = Backbone.View.extend
     @collection = new EvolutionCollection()
     @collection.on "sync", @dataLoaded.bind @
     @collection.fetch()
-    
+
   dataLoaded: (param) ->
     @$el.unmask()
 
@@ -54,3 +54,9 @@ ViewFiltersEvolution = Backbone.View.extend
     filter = el.attr 'data-filter'
     value = el.attr 'data-value'
     @set filter, value
+    dataLayer.push({
+      'event': 'dependencyFilterTrigger',
+      'dependencyFilterActionVariable': 'clicked Depdendency Filter',
+      'dependencyFilterValueVariable': el['0'].innerText,
+      'dependencyFilterLocationVariable': window.location.href
+    })

--- a/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Didactic/Proficiency/view-filters-proficiency.coffee
+++ b/src/GimmeBundle/Resources/assets/javascript/src/ProvaBrasil/Didactic/Proficiency/view-filters-proficiency.coffee
@@ -3,7 +3,7 @@
  * Quando for uma página de escola, gerencia o bloco de escola
  * quando for de município, o bloco do município dono da página
  * e assim por diante...
- * 
+ *
  * Este bloco engloba também o filtro seletor.
 ###
 ViewFiltersProficiency = Backbone.View.extend
@@ -14,8 +14,8 @@ ViewFiltersProficiency = Backbone.View.extend
   statemenu: null
 
   events:
-    'click .nav-pills li a' : 'clickDimensionFilter'    
-  
+    'click .nav-pills li a' : 'clickDimensionFilter'
+
   initialize: (@options) ->
     @statemenu = new StateMenu @options.stateMenuConfigs
 
@@ -57,8 +57,14 @@ ViewFiltersProficiency = Backbone.View.extend
   clickDimensionFilter: (ev) ->
     ev.preventDefault()
     el = $ ev.currentTarget
-    
+
     #get data to filter
     filter = el.attr 'data-filter'
     value = el.attr 'data-value'
     @set filter, value
+    dataLayer.push({
+      'event': 'dependencyFilterTrigger',
+      'dependencyFilterActionVariable': 'clicked Depdendency Filter',
+      'dependencyFilterValueVariable': el['0'].innerText,
+      'dependencyFilterLocationVariable': window.location.href
+    })


### PR DESCRIPTION
## Description 

Add GTM tracking in Dependency filters

## Motivation and context

Know how our user users the site

## Main Changes

- The site is now tracking clicks in Dependency filters in Aprendizado, Compare and Explore pages.