### PR TITLE
Improve learning query performance

### DIFF
--- a/src/AppBundle/Entity/School.php
+++ b/src/AppBundle/Entity/School.php
@@ -164,5 +164,4 @@ class School
     {
         $this->localizationId = $localizationId;
     }
-
 }

--- a/src/AppBundle/Entity/School.php
+++ b/src/AppBundle/Entity/School.php
@@ -76,6 +76,20 @@ class School
      */
     private $slug;
 
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="dependence_id", type="integer", nullable=false)
+     */
+    private $dependenceId;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="localization_id", type="integer", nullable=false)
+     */
+    private $localizationId;
+
     public function getId(): int
     {
         return $this->id;
@@ -130,4 +144,25 @@ class School
     {
         $this->slug = $slug;
     }
+
+    public function getDependenceId(): int
+    {
+        return $this->dependenceId;
+    }
+
+    public function setDependenceId(int $dependenceId)
+    {
+        $this->dependenceId = $dependenceId;
+    }
+
+    public function getLocalizationId(): int
+    {
+        return $this->localizationId;
+    }
+
+    public function setLocalizationId(int $localizationId)
+    {
+        $this->localizationId = $localizationId;
+    }
+
 }

--- a/src/AppBundle/Learning/LearningService.php
+++ b/src/AppBundle/Learning/LearningService.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Learning;
 
+use AppBundle\Entity\School;
 use AppBundle\Repository\ProficiencyRepositoryInterface;
 
 class LearningService
@@ -24,10 +25,10 @@ class LearningService
         return $this->learningFactory->create($brazilProficiency);
     }
 
-    public function getSchoolLearningByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition): array
+    public function getSchoolLearningByEdition(School $school, ProvaBrasilEdition $provaBrasilEdition): array
     {
         $schoolProficiency = $this->proficiencyRepository->findSchoolProficiencyByEdition(
-            $schoolId,
+            $school,
             $provaBrasilEdition
         );
 

--- a/src/AppBundle/Repository/ProficiencyRepository.php
+++ b/src/AppBundle/Repository/ProficiencyRepository.php
@@ -4,6 +4,7 @@ namespace AppBundle\Repository;
 
 use AppBundle\Entity\DimPoliticAggregation;
 use AppBundle\Entity\DimRegionalAggregation;
+use AppBundle\Entity\School;
 use AppBundle\Learning\ProvaBrasilEdition;
 use Doctrine\ORM\EntityRepository;
 
@@ -12,8 +13,6 @@ class ProficiencyRepository extends EntityRepository implements ProficiencyRepos
     public function findBrazilProficiencyByEdition(ProvaBrasilEdition $provaBrasilEdition)
     {
         $queryBuilder = $this->createQueryBuilder('p');
-
-        $editionCode = $provaBrasilEdition->getCode();
 
         return $queryBuilder
             ->join(DimRegionalAggregation::class, 'dra', 'WITH', 'p.dimRegionalAggregationId = dra.id')
@@ -24,29 +23,35 @@ class ProficiencyRepository extends EntityRepository implements ProficiencyRepos
             ->join(DimPoliticAggregation::class, 'dpa', 'WITH', 'p.dimPoliticAggregationId = dpa.id')
             ->andWhere('dpa.localizationId = 0')
             ->andWhere('dpa.dependenceId = 0')
+            ->andWhere('dpa.editionId = ' . $provaBrasilEdition->getCode())
 
-            ->andWhere('dpa.editionId= '.$editionCode)
             ->addOrderBy('dpa.disciplineId')
             ->addOrderBy('dpa.gradeId')
+
             ->getQuery()
             ->getResult();
     }
 
-    public function findSchoolProficiencyByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition)
+    public function findSchoolProficiencyByEdition(School $school, ProvaBrasilEdition $provaBrasilEdition)
     {
         $queryBuilder = $this->createQueryBuilder('p');
 
-        $editionCode = $provaBrasilEdition->getCode();
-
         return $queryBuilder
             ->join(DimRegionalAggregation::class, 'dra', 'WITH', 'p.dimRegionalAggregationId = dra.id')
-            ->andWhere('dra.schoolId = '.$schoolId)
+            ->andWhere('dra.schoolId = ' . $school->getId())
+            ->andWhere('dra.teamId = 0')
+            ->andWhere('dra.cityGroupId = 0')
 
             ->join(DimPoliticAggregation::class, 'dpa', 'WITH', 'p.dimPoliticAggregationId = dpa.id')
+            ->andWhere('dpa.editionId = ' . $provaBrasilEdition->getCode())
+            ->andWhere('dpa.dependenceId = ' . $school->getDependenceId())
+            ->andWhere('dpa.localizationId = ' . $school->getLocalizationId())
+            ->andWhere('dpa.disciplineId in (1, 2)')
+            ->andWhere('dpa.gradeId in (5, 9)')
 
-            ->andWhere('dpa.editionId = '.$editionCode)
             ->addOrderBy('dpa.disciplineId')
             ->addOrderBy('dpa.gradeId')
+
             ->getQuery()
             ->getResult();
     }

--- a/src/AppBundle/Repository/ProficiencyRepositoryInterface.php
+++ b/src/AppBundle/Repository/ProficiencyRepositoryInterface.php
@@ -2,10 +2,11 @@
 
 namespace AppBundle\Repository;
 
+use AppBundle\Entity\School;
 use AppBundle\Learning\ProvaBrasilEdition;
 
 interface ProficiencyRepositoryInterface
 {
     public function findBrazilProficiencyByEdition(ProvaBrasilEdition $provaBrasilEdition);
-    public function findSchoolProficiencyByEdition(int $schoolId, ProvaBrasilEdition $provaBrasilEdition);
+    public function findSchoolProficiencyByEdition(School $school, ProvaBrasilEdition $provaBrasilEdition);
 }

--- a/tests/functional/AppBundle/Controller/LearningControllerTest.php
+++ b/tests/functional/AppBundle/Controller/LearningControllerTest.php
@@ -28,7 +28,7 @@ class LearningControllerTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', '/escola/9999999-non-existent/aprendizado');
+        $client->request('GET', '/amp/escola/9999999-non-existent/aprendizado');
 
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
     }

--- a/tests/integration/AppBundle/Repository/ProficiencyRepositoryTest.php
+++ b/tests/integration/AppBundle/Repository/ProficiencyRepositoryTest.php
@@ -3,15 +3,19 @@
 namespace Tests\Integration\AppBundle\Repository;
 
 use AppBundle\Entity\Proficiency;
+use AppBundle\Entity\School;
 use AppBundle\Learning\ProvaBrasilEdition;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Tests\Fixture\Database\ProficiencyTableFixture;
+use Tests\Fixture\Database\SchoolTableFixture;
 use Tests\Fixture\ProficiencyEntityFixture;
 
 class ProficiencyRepositoryTest extends KernelTestCase
 {
-    private $em;
+    private $emProficiency;
+    private $emSchool;
     private $proficiencyTableFixture;
+    private $schoolTableFixture;
 
     public function testFindBrazilProficiencyByEdition()
     {
@@ -19,7 +23,7 @@ class ProficiencyRepositoryTest extends KernelTestCase
 
         $proficiencyExpected = ProficiencyEntityFixture::getProficiency();
 
-        $proficiencies = $this->em
+        $proficiencies = $this->emProficiency
             ->getRepository(Proficiency::class)
             ->findBrazilProficiencyByEdition(new ProvaBrasilEdition(6, 2015));
 
@@ -52,6 +56,7 @@ class ProficiencyRepositoryTest extends KernelTestCase
 
     public function testFindSchoolProficiencyByEdition()
     {
+        $this->schoolTableFixture->populateWithSchoolRegister();
         $this->proficiencyTableFixture->populateWithSchoolRegister();
 
         $proficiencyExpected = new Proficiency();
@@ -63,9 +68,13 @@ class ProficiencyRepositoryTest extends KernelTestCase
         $proficiencyExpected->setQualitative3('3.13');
 
         $schoolId = 142950;
-        $proficiencies = $this->em
+        $school = $this->emSchool
+            ->getRepository(School::class)
+            ->find($schoolId);
+
+        $proficiencies = $this->emProficiency
             ->getRepository(Proficiency::class)
-            ->findSchoolProficiencyByEdition($schoolId, new ProvaBrasilEdition(6, 2015));
+            ->findSchoolProficiencyByEdition($school, new ProvaBrasilEdition(6, 2015));
 
         $this->assertCount(4, $proficiencies);
         $this->assertEquals(
@@ -101,7 +110,11 @@ class ProficiencyRepositoryTest extends KernelTestCase
         $this->proficiencyTableFixture = new ProficiencyTableFixture();
         $this->proficiencyTableFixture->createTable($kernel);
 
-        $this->em = $this->proficiencyTableFixture->getEntityManager();
+        $this->schoolTableFixture = new SchoolTableFixture();
+        $this->schoolTableFixture->createTable($kernel);
+
+        $this->emProficiency = $this->proficiencyTableFixture->getEntityManager();
+        $this->emSchool = $this->schoolTableFixture->getEntityManager();
     }
 
     protected function tearDown()
@@ -109,5 +122,6 @@ class ProficiencyRepositoryTest extends KernelTestCase
         parent::tearDown();
 
         $this->proficiencyTableFixture->dropTable();
+        $this->schoolTableFixture->dropTable();
     }
 }

--- a/tests/unit/AppBundle/Learning/LearningServiceTest.php
+++ b/tests/unit/AppBundle/Learning/LearningServiceTest.php
@@ -30,10 +30,10 @@ class LearningServiceTest extends TestCase
         $proficiencyRepositoryMock = $this->getProficiencyRepositoryMockInSchoolCase();
         $learningFactoryMock = $this->getLearningFactoryMock();
         $provaBrasilEdition = ProvaBrasilEditionFixture::getProvaBrasilEdition();
-        $schoolId = 12392;
+        $schoolMock = $this->getSchoolEntityMock();
 
         $learningService = new LearningService($proficiencyRepositoryMock, $learningFactoryMock);
-        $schoolLearning = $learningService->getSchoolLearningByEdition($schoolId, $provaBrasilEdition);
+        $schoolLearning = $learningService->getSchoolLearningByEdition($schoolMock, $provaBrasilEdition);
 
         $schoolLearningExpected = LearningFixture::getLearningCollection();
 
@@ -59,18 +59,29 @@ class LearningServiceTest extends TestCase
     {
         $proficiencyRepository = $this->getProficiencyRepositoryMock();
 
+        $schoolExpected = $this->getSchoolEntityMock();
         $provaBrasilEdition = ProvaBrasilEditionFixture::getProvaBrasilEdition();
         $proficiencyEntity = ProficiencyEntityFixture::getProficiencyEntities();
 
         $proficiencyRepository->expects($this->once())
             ->method('findSchoolProficiencyByEdition')
             ->with(
-                $this->equalTo(12392),
+                $this->equalTo($schoolExpected),
                 $this->equalTo($provaBrasilEdition)
             )
             ->willReturn($proficiencyEntity);
 
         return $proficiencyRepository;
+    }
+
+    private function getSchoolEntityMock()
+    {
+        $schoolMock = $this->createMock('AppBundle\Entity\School');
+
+        $schoolMock->method('getId')
+            ->willReturn(12392);
+
+        return $schoolMock;
     }
 
     private function getProficiencyRepositoryMock()


### PR DESCRIPTION
## Description

Improve school learning route performance adding others criteria in the query executed in
the database. Also we needed update the: repository, service and controller, and change the
ProficiencyRepositoryInterface to receive Entity/School instead of school id.

## Motivation and context

The performance of `learning_school` route is very poor harming QEdu Hub as whole.

## Main Changes

- Update query implementation in the `ProficiencyRepository`.
- Update `getSchoolLearningByEdition` method signature in `ProficiencyRepositoryInterface`.

## Screenshots

![screen shot 2018-04-25 at 5 36 05 pm](https://user-images.githubusercontent.com/1117674/39271358-335e1c52-48af-11e8-9676-8db0dc07cd46.png)
