### PR TITLE
Add development route to partially deploy the new school census page

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,7 +7,7 @@ checks:
 build:
     environment:
         php: '7.1.12'
-        node: 'v0.10.25'
+        node: 'v6.13.0'
     tests:
         override:
             -

--- a/app/Resources/views/census/school.html.twig
+++ b/app/Resources/views/census/school.html.twig
@@ -1,0 +1,26 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{% endblock %}
+
+{% block description %}{% endblock %}
+{% block og_title %}{% endblock %}
+{% block og_description %}{% endblock %}
+
+{% block body %}
+  content
+{% endblock %}
+
+{% block stylesheets %}
+  <link type="text/css" href="/gimme/d3e1a7d09b/pkg/css/provabrasil.css" rel="stylesheet">
+  <link type="text/css" href="/gimme/cfdcda464f/pkg/css/provabrasil/dropdown-select2.css" rel="stylesheet"/>
+{% endblock %}
+
+{% block javascripts %}
+  <script type="text/javascript" src="/gimme/ddfef5b5e4/pkg/js/mcc-boot.js"></script>
+  <script type="text/javascript" src="/gimme/2a854d73fb/pkg/js/QEdu/Header.js"></script>
+  <script type="text/javascript">
+    mcc.init_behaviors({
+        "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}]
+    });
+  </script>
+{% endblock %}

--- a/src/AppBundle/Controller/CensusController.php
+++ b/src/AppBundle/Controller/CensusController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class CensusController extends Controller
+{
+    /**
+     * @Route("/escola/{schoolId}-{schoolSlug}/sobre-dev",
+     *     name="census_school",
+     *     requirements={
+     *         "schoolId": "\d+",
+     *         "schoolSlug": ".*"
+     *     }
+     * )
+     */
+    public function schoolAction()
+    {
+        return $this->render('census/school.html.twig');
+    }
+}

--- a/src/AppBundle/Entity/School.php
+++ b/src/AppBundle/Entity/School.php
@@ -115,32 +115,32 @@ class School
         $this->name = $name;
     }
 
-    public function getNamePrefix(): string
+    public function getNamePrefix(): ?string
     {
         return $this->namePrefix;
     }
 
-    public function setNamePrefix(string $namePrefix)
+    public function setNamePrefix(?string $namePrefix)
     {
         $this->namePrefix = $namePrefix;
     }
 
-    public function getNameStandard(): string
+    public function getNameStandard(): ?string
     {
         return $this->nameStandard;
     }
 
-    public function setNameStandard(string $nameStandard)
+    public function setNameStandard(?string $nameStandard)
     {
         $this->nameStandard = $nameStandard;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
-    public function setSlug(string $slug)
+    public function setSlug(?string $slug)
     {
         $this->slug = $slug;
     }


### PR DESCRIPTION
## Description

Add development route `/escola/<schoolId-schoolSlug>/sobre-dev` to partially deploy the new school census page

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub

Migration of about school page.

## Others issues

- Update node version in scrutinize config.
- Fix School entity.

## Screenshot

![screen shot 2018-05-10 at 5 38 59 pm](https://user-images.githubusercontent.com/1117674/39893087-161ef2a8-5479-11e8-8917-12e821cea8bb.png)
