### PR TITLE
Add school breadcrumb

### DIFF
--- a/app/Resources/views/census/school.html.twig
+++ b/app/Resources/views/census/school.html.twig
@@ -7,7 +7,7 @@
 {% block og_description %}{% endblock %}
 
 {% block body %}
-  content
+  {% include 'census/subnav.html.twig' %}
 {% endblock %}
 
 {% block stylesheets %}
@@ -18,9 +18,30 @@
 {% block javascripts %}
   <script type="text/javascript" src="/gimme/ddfef5b5e4/pkg/js/mcc-boot.js"></script>
   <script type="text/javascript" src="/gimme/2a854d73fb/pkg/js/QEdu/Header.js"></script>
+  <script type="text/javascript" src="/gimme/f46964a241/pkg/js/select2-lib.js"></script>
+  <script type="text/javascript" src="/gimme/85d63f33ed/pkg/js/provabrasil/dropdown-select2.js"></script>
   <script type="text/javascript">
     mcc.init_behaviors({
-        "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}]
+        "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}],
+
+        "behavior-dropdown-select2":[
+
+            {% for item in breadcrumb.getItems() if item['type'] != 'country' %}
+              {
+                  "fetch_from": "{{ item['ajax_dropdown_url'] }}",
+                  "formatSearchingText": "{{ item['search_text'] }}",
+                  "placeholder_input": "{{ item['placeholder'] }}",
+                  "formatNoMatches": "Nenhum resultado para \"%s\".",
+                  "extra_dropdown_classes": " select2-breadcrumb-box",
+                  "idElement": "{{ item['element_id'] }}"
+
+                {% if item['type'] == 'school' %}
+                  ,"message_bottom": 'Listando escolas p\u00fablicas participantes da Prova Brasil<br/><a href="javascript:void(0)" class="select2-redirect" data-url="{{ item['message_bottom_url'] }}">Veja a lista completa de escolas (incluindo particulares) na busca guiada</a>'
+                {% endif %}
+              },
+            {% endfor %}
+
+        ]
     });
   </script>
 {% endblock %}

--- a/app/Resources/views/census/subnav.html.twig
+++ b/app/Resources/views/census/subnav.html.twig
@@ -1,0 +1,36 @@
+<section class="subnav-section gray-pattern">
+
+  <div class="container with-avatar-small">
+
+    <div class="subnav-title">
+      <ul class="subnav-breadcrumb">
+
+        {% for item in breadcrumb.getItems() %}
+          <li>
+            <a href="{{ item['url'] }}">{{ item['name'] }}</a>
+            <input type="hidden" id="{{ item['element_id'] }}" />
+          </li>
+        {% endfor %}
+
+      </ul>
+    </div>
+    <div class="clearfix"></div>
+
+    <div class="block-image thumbnail avatar-block-small ">
+      <a href="#" rel="tooltip" title="" class="avatar-container" data-original-title="">
+        <img src="/img/provabrasil/avatar/school-128px.png">-
+      </a>
+    </div>
+
+    <div class="subnav-title">
+      <h1></h1>
+    </div>
+
+    <div class="action-buttons social-section">
+      <div class="addthis_sharing_toolbox"></div>
+    </div>
+  </div>
+
+</section>
+
+<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-542c488254cb45ee" async></script>

--- a/src/AppBundle/Controller/CensusController.php
+++ b/src/AppBundle/Controller/CensusController.php
@@ -2,8 +2,10 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Util\Breadcrumb;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 class CensusController extends Controller
 {
@@ -16,8 +18,16 @@ class CensusController extends Controller
      *     }
      * )
      */
-    public function schoolAction()
+    public function schoolAction(Request $request, int $schoolId)
     {
-        return $this->render('census/school.html.twig');
+        $school = $this->getDoctrine()
+            ->getRepository('AppBundle:School', 'waitress_entities')
+            ->find($schoolId);
+
+        $breadcrumb = new Breadcrumb($school, $request);
+
+        return $this->render('census/school.html.twig', [
+            'breadcrumb' => $breadcrumb,
+        ]);
     }
 }

--- a/src/AppBundle/Entity/City.php
+++ b/src/AppBundle/Entity/City.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * City
+ *
+ * @ORM\Table(name="city",
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(name="id_ibge_UNIQUE", columns={"ibge_id"})
+ *     },
+ *     indexes={
+ *         @ORM\Index(name="fk_citie_state1", columns={"state_id"}),
+ *         @ORM\Index(name="name_standard", columns={"name_standard"}),
+ *         @ORM\Index(name="name", columns={"name"}),
+ *         @ORM\Index(name="enem", columns={"id", "ibge_id"})
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class City
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="smallint", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="ibge_id", type="integer", nullable=false)
+     */
+    private $ibgeId;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", length=40, nullable=false)
+     */
+    private $name;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name_standard", type="string", length=40, nullable=false)
+     */
+    private $nameStandard;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="slug", type="string", length=40, nullable=false)
+     */
+    private $slug;
+
+    /**
+     * @var \AppBundle\Entity\State
+     *
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\State")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="state_id", referencedColumnName="id")
+     * })
+     */
+    private $state;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getIbgeId(): int
+    {
+        return $this->ibgeId;
+    }
+
+    public function setIbgeId(int $ibgeId)
+    {
+        $this->ibgeId = $ibgeId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getNameStandard(): string
+    {
+        return $this->nameStandard;
+    }
+
+    public function setNameStandard(string $nameStandard)
+    {
+        $this->nameStandard = $nameStandard;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getState(): State
+    {
+        return $this->state;
+    }
+
+    public function setState(State $state)
+    {
+        $this->state = $state;
+    }
+}

--- a/src/AppBundle/Entity/School.php
+++ b/src/AppBundle/Entity/School.php
@@ -9,25 +9,23 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(name="school",
  *     uniqueConstraints={
- *      @ORM\UniqueConstraint(
- *          name="ibge",
- *          columns={"ibge_id"}
- *     ), @ORM\UniqueConstraint(
- *          name="enem",
- *          columns={"id", "city_id", "state_id", "ibge_id"}
- *     )}, indexes={
- *      @ORM\Index(name="fk_school_dependence1", columns={"dependence_id"}),
- *      @ORM\Index(name="fk_school_localization1", columns={"localization_id"}),
- *      @ORM\Index(name="fk_school_operating_conditions1", columns={"operating_conditions_id"}),
- *      @ORM\Index(name="name", columns={"name_standard"}),
- *      @ORM\Index(name="prefix_and_name",columns={"name_prefix", "name_standard"}),
- *      @ORM\Index(name="fk_school_city1", columns={"city_id"}),
- *      @ORM\Index(name="fk_school_state1", columns={"state_id"}),
- *      @ORM\Index(name="fast_search", columns={"state_id", "city_id", "id"}),
- *      @ORM\Index(name="name_2", columns={"name"}),
- *      @ORM\Index(name="city_name", columns={"city_id", "name"}),
- *      @ORM\Index(name="Enem Average", columns={"ibge_id", "state_id", "city_id"})})
- * @ORM\Entity
+ *         @ORM\UniqueConstraint(name="ibge", columns={"ibge_id"}),
+ *         @ORM\UniqueConstraint(name="enem", columns={"id", "city_id", "state_id", "ibge_id"})
+ *     },
+ *     indexes={
+ *         @ORM\Index(name="fk_school_dependence1", columns={"dependence_id"}),
+ *         @ORM\Index(name="fk_school_localization1", columns={"localization_id"}),
+ *         @ORM\Index(name="fk_school_operating_conditions1", columns={"operating_conditions_id"}),
+ *         @ORM\Index(name="name", columns={"name_standard"}),
+ *         @ORM\Index(name="prefix_and_name", columns={"name_prefix", "name_standard"}),
+ *         @ORM\Index(name="fk_school_city1", columns={"city_id"}),
+ *         @ORM\Index(name="fk_school_state1", columns={"state_id"}),
+ *         @ORM\Index(name="fast_search", columns={"state_id", "city_id", "id"}),
+ *         @ORM\Index(name="name_2", columns={"name"}),
+ *         @ORM\Index(name="city_name", columns={"city_id", "name"}),
+ *         @ORM\Index(name="Enem Average", columns={"ibge_id", "state_id", "city_id"})
+ *     }
+ * )
  * @ORM\Entity(repositoryClass="AppBundle\Repository\SchoolRepository")
  */
 class School
@@ -89,6 +87,26 @@ class School
      * @ORM\Column(name="localization_id", type="integer", nullable=false)
      */
     private $localizationId;
+
+    /**
+     * @var \AppBundle\Entity\City
+     *
+     * @ORM\ManyToOne(targetEntity="City")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="city_id", referencedColumnName="id")
+     * })
+     */
+    private $city;
+
+    /**
+     * @var \AppBundle\Entity\State
+     *
+     * @ORM\ManyToOne(targetEntity="State")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="state_id", referencedColumnName="id")
+     * })
+     */
+    private $state;
 
     public function getId(): int
     {
@@ -163,5 +181,25 @@ class School
     public function setLocalizationId(int $localizationId)
     {
         $this->localizationId = $localizationId;
+    }
+
+    public function getCity(): City
+    {
+        return $this->city;
+    }
+
+    public function setCity(City $city)
+    {
+        $this->city = $city;
+    }
+
+    public function getState(): State
+    {
+        return $this->state;
+    }
+
+    public function setState(State $state)
+    {
+        $this->state = $state;
     }
 }

--- a/src/AppBundle/Entity/State.php
+++ b/src/AppBundle/Entity/State.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * State
+ *
+ * @ORM\Table(name="state",
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(name="ibge_id", columns={"ibge_id"})
+ *     },
+ *     indexes={
+ *         @ORM\Index(name="name", columns={"name"}),
+ *         @ORM\Index(name="enem", columns={"id", "ibge_id"})
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class State
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="smallint", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", length=40, nullable=false)
+     */
+    private $name;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="slug", type="string", length=40, nullable=false)
+     */
+    private $slug;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="ibge_id", type="integer", nullable=true)
+     */
+    private $ibgeId;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="acronym", type="string", length=2, nullable=true)
+     */
+    private $acronym;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="region", type="string", length=15, nullable=true)
+     */
+    private $region;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getIbgeId(): int
+    {
+        return $this->ibgeId;
+    }
+
+    public function setIbgeId(int $ibgeId)
+    {
+        $this->ibgeId = $ibgeId;
+    }
+
+    public function getAcronym(): string
+    {
+        return $this->acronym;
+    }
+
+    public function setAcronym(string $acronym)
+    {
+        $this->acronym = $acronym;
+    }
+
+    public function getRegion(): string
+    {
+        return $this->region;
+    }
+
+    public function setRegion(string $region)
+    {
+        $this->region = $region;
+    }
+}

--- a/src/AppBundle/Util/Breadcrumb.php
+++ b/src/AppBundle/Util/Breadcrumb.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace AppBundle\Util;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Breadcrumb
+{
+    private $entity;
+    private $request;
+
+    public function __construct($entity, Request $request)
+    {
+        $this->entity = $entity;
+        $this->request = $request;
+    }
+
+    public function getItems()
+    {
+        return [
+            $this->getCountryConfiguration(),
+            $this->getStateConfiguration(),
+            $this->getCityConfiguration(),
+            $this->getSchoolConfiguration(),
+        ];
+    }
+
+    private function getLastUrlSegment()
+    {
+        $urlSegments = explode('/', $this->request->getPathInfo());
+        $lastUrlSegment = end($urlSegments);
+
+        return $lastUrlSegment;
+    }
+
+    private function getCountryConfiguration()
+    {
+        return [
+            'type' => 'country',
+            'name' => 'Brasil',
+            'url' => sprintf('/brasil/%s', $this->getLastUrlSegment()),
+            'element_id' => 'breadcrumb_country',
+            'ajax_dropdown_url' => '',
+            'search_text' => '',
+            'placeholder' => '',
+        ];
+    }
+
+    private function getStateConfiguration()
+    {
+        $state = $this->entity->getState();
+
+        return [
+            'type' => 'state',
+            'name' => $state->getName(),
+            'url' => sprintf(
+                '/estado/%s-%s/%s',
+                $state->getId(),
+                $state->getSlug(),
+                $this->getLastUrlSegment()
+            ),
+            'element_id' => 'breadcrumb_state',
+            'ajax_dropdown_url' => sprintf(
+                '/ajax/dropdown/remote/states/%s/?url_default=/%s',
+                $state->getId(),
+                $this->getLastUrlSegment()
+            ),
+            'search_text' => 'Carregando estados',
+            'placeholder' => 'Busque por estado...',
+        ];
+    }
+
+    private function getCityConfiguration()
+    {
+        $state = $this->entity->getState();
+        $city = $this->entity->getCity();
+
+        return [
+            'type' => 'city',
+            'name' => $city->getName(),
+            'url' => sprintf(
+                '/cidade/%s-%s/%s',
+                $city->getId(),
+                $city->getSlug(),
+                $this->getLastUrlSegment()
+            ),
+            'element_id' => 'breadcrumb_city',
+            'ajax_dropdown_url' => sprintf(
+                '/ajax/dropdown/remote/cities/%s/%s?url_default=/%s',
+                $state->getId(),
+                $city->getId(),
+                $this->getLastUrlSegment()
+            ),
+            'search_text' => 'Carregando munic\u00edpios',
+            'placeholder' => 'Busque por cidade...',
+        ];
+    }
+
+    private function getSchoolConfiguration()
+    {
+        $state = $this->entity->getState();
+        $city = $this->entity->getCity();
+
+        return [
+            'type' => 'school',
+            'name' => $this->entity->getName(),
+            'url' => sprintf(
+                '/escola/%s-%s/%s',
+                $this->entity->getId(),
+                $this->entity->getSlug(),
+                $this->getLastUrlSegment()
+            ),
+            'element_id' => 'breadcrumb_school',
+            'ajax_dropdown_url' => sprintf(
+                '/ajax/dropdown/remote/schools/%s/%s?url_default=/%s',
+                $state->getId(),
+                $city->getId(),
+                $this->getLastUrlSegment()
+            ),
+            'search_text' => 'Carregando escolas...',
+            'placeholder' => 'Busque por escola...',
+            'message_bottom_url' => sprintf(
+                '/busca/%s-%s/%s-%s',
+                $state->getId(),
+                $state->getSlug(),
+                $city->getId(),
+                $city->getSlug()
+            ),
+        ];
+    }
+}

--- a/tests/unit/AppBundle/Util/BreadcrumbTest.php
+++ b/tests/unit/AppBundle/Util/BreadcrumbTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Unit\AppBundle\Util\Filter;
+
+use AppBundle\Util\Breadcrumb;
+use PHPUnit\Framework\TestCase;
+
+class BreadcrumbTest extends TestCase
+{
+    public function testBuildSchoolBreadcrumb()
+    {
+        $school = $this->getSchoolMock();
+        $request = $this->getRequestMock();
+
+        $breadcrumb = new Breadcrumb($school, $request);
+        $items = $breadcrumb->getItems();
+
+        $itemsExpected = $this->getSchoolItemsExpected();
+
+        $this->assertEquals($itemsExpected, $items);
+    }
+
+    private function getSchoolMock()
+    {
+        $cityMock = $this->getCityMock();
+        $stateMock = $this->getStateMock();
+
+        $schoolMock = $this->createMock('AppBundle\Entity\School');
+        $schoolMock->method('getId')
+            ->willReturn(156485);
+
+        $schoolMock->method('getName')
+            ->willReturn('EE BELMIRO BRAGA');
+
+        $schoolMock->method('getSlug')
+            ->willReturn('ee-belmiro-braga');
+
+        $schoolMock->method('getCity')
+            ->willReturn($cityMock);
+
+        $schoolMock->method('getState')
+            ->willReturn($stateMock);
+
+        return $schoolMock;
+    }
+
+    private function getCityMock()
+    {
+        $cityMock = $this->createMock('AppBundle\Entity\City');
+
+        $cityMock->method('getId')
+            ->willReturn(1597);
+
+        $cityMock->method('getName')
+            ->willReturn('Boa Esperança');
+
+        $cityMock->method('getSlug')
+            ->willReturn('boa-esperanca');
+
+        return $cityMock;
+    }
+
+    private function getStateMock()
+    {
+        $stateMock = $this->createMock('AppBundle\Entity\State');
+
+        $stateMock->method('getId')
+            ->willReturn(113);
+
+        $stateMock->method('getName')
+            ->willReturn('Minas Gerais');
+
+        $stateMock->method('getSlug')
+            ->willReturn('minas-gerais');
+
+        return $stateMock;
+    }
+
+    private function getRequestMock()
+    {
+        $requestMock = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $requestMock->method('getPathInfo')
+            ->willReturn('/escola/156485-ee-belmiro-braga/sobre');
+
+        return $requestMock;
+    }
+
+    private function getSchoolItemsExpected()
+    {
+        return [
+            [
+                'type' => 'country',
+                'name' => 'Brasil',
+                'url' => '/brasil/sobre',
+                'element_id' => 'breadcrumb_country',
+                'ajax_dropdown_url' => '',
+                'search_text' => '',
+                'placeholder' => '',
+            ],
+            [
+                'type' => 'state',
+                'name' => 'Minas Gerais',
+                'url' => '/estado/113-minas-gerais/sobre',
+                'element_id' => 'breadcrumb_state',
+                'ajax_dropdown_url' => '/ajax/dropdown/remote/states/113/?url_default=/sobre',
+                'search_text' => 'Carregando estados',
+                'placeholder' => 'Busque por estado...',
+            ],
+            [
+                'type' => 'city',
+                'name' => 'Boa Esperança',
+                'url' => '/cidade/1597-boa-esperanca/sobre',
+                'element_id' => 'breadcrumb_city',
+                'ajax_dropdown_url' => '/ajax/dropdown/remote/cities/113/1597?url_default=/sobre',
+                'search_text' => 'Carregando munic\u00edpios',
+                'placeholder' => 'Busque por cidade...',
+            ],
+            [
+                'type' => 'school',
+                'name' => 'EE BELMIRO BRAGA',
+                'url' => '/escola/156485-ee-belmiro-braga/sobre',
+                'element_id' => 'breadcrumb_school',
+                'ajax_dropdown_url' => '/ajax/dropdown/remote/schools/113/1597?url_default=/sobre',
+                'search_text' => 'Carregando escolas...',
+                'placeholder' => 'Busque por escola...',
+                'message_bottom_url' => '/busca/113-minas-gerais/1597-boa-esperanca',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
## Description

Add breadcrumb in school pages.

- Add Breadcrumb class and tests.
- Update Census controller.
- Add subnav view.
- Update School entity with state and city.
- Add State and City entities.

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub

Migration of about school page.

## Screenshot

<img width="478" alt="screen shot 2018-05-15 at 7 23 35 pm" src="https://user-images.githubusercontent.com/1117674/40086648-a296f3f2-5875-11e8-8ca0-19bf85934ba5.png">
