### PR TITLE
Add Dynamic School Menu

### DIFF
--- a/app/Resources/views/census/school.html.twig
+++ b/app/Resources/views/census/school.html.twig
@@ -26,7 +26,7 @@
 
         "behavior-dropdown-select2":[
 
-            {% for item in breadcrumb.getItems() if item['type'] != 'country' %}
+            {% for item in breadcrumbItems if item['type'] != 'country' %}
               {
                   "fetch_from": "{{ item['ajax_dropdown_url'] }}",
                   "formatSearchingText": "{{ item['search_text'] }}",

--- a/app/Resources/views/census/subnav.html.twig
+++ b/app/Resources/views/census/subnav.html.twig
@@ -31,6 +31,15 @@
     </div>
   </div>
 
+  <div class="subnav with-avatar-small-margin">
+    <ul class="nav nav-pills">
+      {% for item in menuItems %}
+        <li class="{{ item['isActive'] ? 'active' : '' }}">
+          <a href="{{ item['url'] }}"><i class="{{ item['icon'] }}"></i>{{ item['name'] }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
 </section>
 
 <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-542c488254cb45ee" async></script>

--- a/app/Resources/views/census/subnav.html.twig
+++ b/app/Resources/views/census/subnav.html.twig
@@ -5,7 +5,7 @@
     <div class="subnav-title">
       <ul class="subnav-breadcrumb">
 
-        {% for item in breadcrumb.getItems() %}
+        {% for item in breadcrumbItems %}
           <li>
             <a href="{{ item['url'] }}">{{ item['name'] }}</a>
             <input type="hidden" id="{{ item['element_id'] }}" />

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -38,4 +38,10 @@ services:
         factory: 'doctrine.orm.waitress_dw_prova_brasil_entity_manager:getRepository'
         arguments: ['AppBundle\Entity\Proficiency']
 
+    AppBundle\Repository\Learning\SchoolRepository:
+        factory: 'doctrine.orm.waitress_dw_prova_brasil_entity_manager:getRepository'
+        arguments: ['AppBundle\Entity\Learning\School']
+
     AppBundle\Repository\ProficiencyRepositoryInterface: '@AppBundle\Repository\ProficiencyRepository'
+
+    AppBundle\Repository\Learning\SchoolRepositoryInterface: '@AppBundle\Repository\Learning\SchoolRepository'

--- a/src/AppBundle/Controller/CensusController.php
+++ b/src/AppBundle/Controller/CensusController.php
@@ -10,10 +10,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CensusController extends Controller
 {
+    private $breadcrumb;
     private $menuBuilder;
 
-    public function __construct(MenuBuilder $menuBuilder)
+    public function __construct(Breadcrumb $breadcrumb, MenuBuilder $menuBuilder)
     {
+        $this->breadcrumb = $breadcrumb;
         $this->menuBuilder = $menuBuilder;
     }
 
@@ -32,12 +34,12 @@ class CensusController extends Controller
             ->getRepository('AppBundle:School', 'waitress_entities')
             ->find($schoolId);
 
-        $breadcrumb = new Breadcrumb($school, $request);
+        $breadcrumbItems = $this->breadcrumb->buildItems($school, $request);
         $menuItems = $this->menuBuilder->buildItems($school, $request);
 
         return $this->render('census/school.html.twig', [
             'school' => $school,
-            'breadcrumb' => $breadcrumb,
+            'breadcrumbItems' => $breadcrumbItems,
             'menuItems' => $menuItems,
         ]);
     }

--- a/src/AppBundle/Controller/CensusController.php
+++ b/src/AppBundle/Controller/CensusController.php
@@ -3,12 +3,20 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Util\Breadcrumb;
+use AppBundle\Util\MenuBuilder;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
 class CensusController extends Controller
 {
+    private $menuBuilder;
+
+    public function __construct(MenuBuilder $menuBuilder)
+    {
+        $this->menuBuilder = $menuBuilder;
+    }
+
     /**
      * @Route("/escola/{schoolId}-{schoolSlug}/sobre-dev",
      *     name="census_school",
@@ -25,10 +33,12 @@ class CensusController extends Controller
             ->find($schoolId);
 
         $breadcrumb = new Breadcrumb($school, $request);
+        $menuItems = $this->menuBuilder->buildItems($school, $request);
 
         return $this->render('census/school.html.twig', [
             'school' => $school,
             'breadcrumb' => $breadcrumb,
+            'menuItems' => $menuItems,
         ]);
     }
 }

--- a/src/AppBundle/Entity/Learning/School.php
+++ b/src/AppBundle/Entity/Learning/School.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace AppBundle\Entity\Learning;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * School
+ *
+ * @ORM\Table(name="school",
+ *     indexes={
+ *         @ORM\Index(name="fk_schools_edition1", columns={"edition_id"}),
+ *         @ORM\Index(name="busca", columns={"state_id", "city_id"}),
+ *         @ORM\Index(name="busca_estado", columns={"state_id"}),
+ *         @ORM\Index(name="edition_city", columns={"edition_id", "city_id"})
+ *     }
+ * )
+ * @ORM\Entity(repositoryClass="AppBundle\Repository\Learning\SchoolRepository")
+ */
+class School
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="NONE")
+     */
+    private $id;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="edition_id", type="smallint", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="NONE")
+     */
+    private $editionId;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="state_id", type="smallint", nullable=false)
+     */
+    private $stateId;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="city_id", type="smallint", nullable=false)
+     */
+    private $cityId;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="localization_id", type="smallint", nullable=true)
+     */
+    private $localizationId;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="dependence_id", type="smallint", nullable=true)
+     */
+    private $dependenceId;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getEditionId(): int
+    {
+        return $this->editionId;
+    }
+
+    public function setEditionId(int $editionId)
+    {
+        $this->editionId = $editionId;
+    }
+
+    public function getStateId(): int
+    {
+        return $this->stateId;
+    }
+
+    public function setStateId(int $stateId)
+    {
+        $this->stateId = $stateId;
+    }
+
+    public function getCityId(): int
+    {
+        return $this->cityId;
+    }
+
+    public function setCityId(int $cityId)
+    {
+        $this->cityId = $cityId;
+    }
+
+    public function getLocalizationId(): int
+    {
+        return $this->localizationId;
+    }
+
+    public function setLocalizationId(int $localizationId)
+    {
+        $this->localizationId = $localizationId;
+    }
+
+    public function getDependenceId(): int
+    {
+        return $this->dependenceId;
+    }
+
+    public function setDependenceId(int $dependenceId)
+    {
+        $this->dependenceId = $dependenceId;
+    }
+}

--- a/src/AppBundle/Learning/ProficiencyInterface.php
+++ b/src/AppBundle/Learning/ProficiencyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AppBundle\Learning;
+
+use AppBundle\Entity\School;
+
+interface ProficiencyInterface
+{
+    public function hasProficiencyInLastEdition(School $school): bool;
+}

--- a/src/AppBundle/Learning/SchoolProficiency.php
+++ b/src/AppBundle/Learning/SchoolProficiency.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AppBundle\Learning;
+
+use AppBundle\Entity\School;
+use AppBundle\Repository\Learning\SchoolRepositoryInterface;
+
+class SchoolProficiency implements ProficiencyInterface
+{
+    private $schoolRepository;
+    private $provaBrasilService;
+
+    public function __construct(SchoolRepositoryInterface $schoolRepository, ProvaBrasilService $provaBrasilService)
+    {
+        $this->schoolRepository = $schoolRepository;
+        $this->provaBrasilService = $provaBrasilService;
+    }
+
+    public function hasProficiencyInLastEdition(School $school): bool
+    {
+        $provaBrasilEdition = $this->provaBrasilService->getLastEdition();
+
+        $schools = $this->schoolRepository->findSchoolProficiencyByEdition($school, $provaBrasilEdition);
+
+        if (count($schools) === 0) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/AppBundle/Repository/Learning/SchoolRepository.php
+++ b/src/AppBundle/Repository/Learning/SchoolRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AppBundle\Repository\Learning;
+
+use AppBundle\Entity\School;
+use AppBundle\Learning\ProvaBrasilEdition;
+use Doctrine\ORM\EntityRepository;
+
+class SchoolRepository extends EntityRepository implements SchoolRepositoryInterface
+{
+    public function findSchoolProficiencyByEdition(School $school, ProvaBrasilEdition $provaBrasilEdition)
+    {
+        return $this->findBy([
+            'id' => $school->getId(),
+            'editionId' => $provaBrasilEdition->getCode(),
+        ]);
+    }
+}

--- a/src/AppBundle/Repository/Learning/SchoolRepositoryInterface.php
+++ b/src/AppBundle/Repository/Learning/SchoolRepositoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AppBundle\Repository\Learning;
+
+use AppBundle\Entity\School;
+use AppBundle\Learning\ProvaBrasilEdition;
+
+interface SchoolRepositoryInterface
+{
+    public function findSchoolProficiencyByEdition(School $school, ProvaBrasilEdition $provaBrasilEdition);
+}

--- a/src/AppBundle/Util/Breadcrumb.php
+++ b/src/AppBundle/Util/Breadcrumb.php
@@ -6,8 +6,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class Breadcrumb
 {
+    use RequestSegmentTrait;
+
     private $entity;
     private $request;
+    private $lastUrlSegment;
 
     public function __construct($entity, Request $request)
     {
@@ -17,6 +20,9 @@ class Breadcrumb
 
     public function getItems()
     {
+        $pathInfo = $this->request->getPathInfo();
+        $this->lastUrlSegment = $this->getLastUrlSegment($pathInfo);
+
         return [
             $this->getCountryConfiguration(),
             $this->getStateConfiguration(),
@@ -25,20 +31,12 @@ class Breadcrumb
         ];
     }
 
-    private function getLastUrlSegment()
-    {
-        $urlSegments = explode('/', $this->request->getPathInfo());
-        $lastUrlSegment = end($urlSegments);
-
-        return $lastUrlSegment;
-    }
-
     private function getCountryConfiguration()
     {
         return [
             'type' => 'country',
             'name' => 'Brasil',
-            'url' => sprintf('/brasil/%s', $this->getLastUrlSegment()),
+            'url' => sprintf('/brasil/%s', $this->lastUrlSegment),
             'element_id' => 'breadcrumb_country',
             'ajax_dropdown_url' => '',
             'search_text' => '',
@@ -57,13 +55,13 @@ class Breadcrumb
                 '/estado/%s-%s/%s',
                 $state->getId(),
                 $state->getSlug(),
-                $this->getLastUrlSegment()
+                $this->lastUrlSegment
             ),
             'element_id' => 'breadcrumb_state',
             'ajax_dropdown_url' => sprintf(
                 '/ajax/dropdown/remote/states/%s/?url_default=/%s',
                 $state->getId(),
-                $this->getLastUrlSegment()
+                $this->lastUrlSegment
             ),
             'search_text' => 'Carregando estados',
             'placeholder' => 'Busque por estado...',
@@ -82,14 +80,14 @@ class Breadcrumb
                 '/cidade/%s-%s/%s',
                 $city->getId(),
                 $city->getSlug(),
-                $this->getLastUrlSegment()
+                $this->lastUrlSegment
             ),
             'element_id' => 'breadcrumb_city',
             'ajax_dropdown_url' => sprintf(
                 '/ajax/dropdown/remote/cities/%s/%s?url_default=/%s',
                 $state->getId(),
                 $city->getId(),
-                $this->getLastUrlSegment()
+                $this->lastUrlSegment
             ),
             'search_text' => 'Carregando munic\u00edpios',
             'placeholder' => 'Busque por cidade...',
@@ -108,14 +106,14 @@ class Breadcrumb
                 '/escola/%s-%s/%s',
                 $this->entity->getId(),
                 $this->entity->getSlug(),
-                $this->getLastUrlSegment()
+                $this->lastUrlSegment
             ),
             'element_id' => 'breadcrumb_school',
             'ajax_dropdown_url' => sprintf(
                 '/ajax/dropdown/remote/schools/%s/%s?url_default=/%s',
                 $state->getId(),
                 $city->getId(),
-                $this->getLastUrlSegment()
+                $this->lastUrlSegment
             ),
             'search_text' => 'Carregando escolas...',
             'placeholder' => 'Busque por escola...',

--- a/src/AppBundle/Util/Breadcrumb.php
+++ b/src/AppBundle/Util/Breadcrumb.php
@@ -8,26 +8,18 @@ class Breadcrumb
 {
     use RequestSegmentTrait;
 
-    private $entity;
-    private $request;
     private $lastUrlSegment;
 
-    public function __construct($entity, Request $request)
+    public function buildItems($entity, Request $request)
     {
-        $this->entity = $entity;
-        $this->request = $request;
-    }
-
-    public function getItems()
-    {
-        $pathInfo = $this->request->getPathInfo();
+        $pathInfo = $request->getPathInfo();
         $this->lastUrlSegment = $this->getLastUrlSegment($pathInfo);
 
         return [
             $this->getCountryConfiguration(),
-            $this->getStateConfiguration(),
-            $this->getCityConfiguration(),
-            $this->getSchoolConfiguration(),
+            $this->getStateConfiguration($entity),
+            $this->getCityConfiguration($entity),
+            $this->getSchoolConfiguration($entity),
         ];
     }
 
@@ -44,9 +36,9 @@ class Breadcrumb
         ];
     }
 
-    private function getStateConfiguration()
+    private function getStateConfiguration($entity)
     {
-        $state = $this->entity->getState();
+        $state = $entity->getState();
 
         return [
             'type' => 'state',
@@ -68,10 +60,10 @@ class Breadcrumb
         ];
     }
 
-    private function getCityConfiguration()
+    private function getCityConfiguration($entity)
     {
-        $state = $this->entity->getState();
-        $city = $this->entity->getCity();
+        $state = $entity->getState();
+        $city = $entity->getCity();
 
         return [
             'type' => 'city',
@@ -94,18 +86,18 @@ class Breadcrumb
         ];
     }
 
-    private function getSchoolConfiguration()
+    private function getSchoolConfiguration($entity)
     {
-        $state = $this->entity->getState();
-        $city = $this->entity->getCity();
+        $state = $entity->getState();
+        $city = $entity->getCity();
 
         return [
             'type' => 'school',
-            'name' => $this->entity->getName(),
+            'name' => $entity->getName(),
             'url' => sprintf(
                 '/escola/%s-%s/%s',
-                $this->entity->getId(),
-                $this->entity->getSlug(),
+                $entity->getId(),
+                $entity->getSlug(),
                 $this->lastUrlSegment
             ),
             'element_id' => 'breadcrumb_school',

--- a/src/AppBundle/Util/MenuBuilder.php
+++ b/src/AppBundle/Util/MenuBuilder.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace AppBundle\Util;
+
+use AppBundle\Entity\School;
+use AppBundle\Learning\ProficiencyInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class MenuBuilder
+{
+    use RequestSegmentTrait;
+
+    private $proficiency;
+    private $items = [
+        'learning' => [
+            'name' => 'Aprendizado',
+            'url' => '/escola/%s-%s/aprendizado',
+            'icon' => 'icon-page-learning',
+            'isActive' => false,
+        ],
+        'compare' => [
+            'name' => 'Compare',
+            'url' => '/escola/%s-%s/compare',
+            'icon' => 'icon-page-compare',
+            'isActive' => false,
+        ],
+        'evolution' => [
+            'name' => 'Evolução',
+            'url' => '/escola/%s-%s/evolucao',
+            'icon' => 'icon-page-evolution',
+            'isActive' => false,
+        ],
+        'proficiency' => [
+            'name' => 'Proficiência',
+            'url' => '/escola/%s-%s/proficiencia',
+            'icon' => 'icon-page-proficiency',
+            'isActive' => false,
+        ],
+        'explore' => [
+            'name' => 'Explore',
+            'url' => '/escola/%s-%s/explorar',
+            'icon' => 'icon-page-explore',
+            'isActive' => false,
+        ],
+        'people' => [
+            'name' => 'Pessoas',
+            'url' => '/escola/%s-%s/pessoas',
+            'icon' => 'icon-page-director',
+            'isActive' => false,
+        ],
+        'census' => [
+            'name' => 'Censo',
+            'url' => '/escola/%s-%s/censo-escolar',
+            'icon' => 'icon-page-census',
+            'isActive' => false,
+        ],
+        'ideb' => [
+            'name' => 'Ideb',
+            'url' => '/escola/%s-%s/ideb',
+            'icon' => 'icon-page-ideb',
+            'isActive' => false,
+        ],
+        'about' => [
+            'name' => 'Sobre a Escola',
+            'url' => '/escola/%s-%s/sobre',
+            'icon' => 'icon-page-about',
+            'isActive' => false,
+        ],
+        'enem' => [
+            'name' => 'Enem',
+            'url' => '/escola/%s-%s/enem',
+            'icon' => 'icon-page-enem',
+            'isActive' => false,
+        ],
+    ];
+
+    public function __construct(ProficiencyInterface $proficiency)
+    {
+        $this->proficiency = $proficiency;
+    }
+
+    public function buildItems(School $school, Request $request)
+    {
+        $this->setActiveItem($request);
+
+        if ($this->proficiency->hasProficiencyInLastEdition($school) === false) {
+            $items[] = $this->items['about'];
+            $items[] = $this->items['enem'];
+
+            $items = $this->mountUrl($items, $school);
+
+            return $items;
+        }
+
+        $items[] = $this->items['learning'];
+        $items[] = $this->items['compare'];
+        $items[] = $this->items['evolution'];
+        $items[] = $this->items['proficiency'];
+        $items[] = $this->items['explore'];
+        $items[] = $this->items['people'];
+        $items[] = $this->items['census'];
+        $items[] = $this->items['ideb'];
+        $items[] = $this->items['enem'];
+
+        $items = $this->mountUrl($items, $school);
+
+        return $items;
+    }
+
+    private function mountUrl(array $items, School $school)
+    {
+        foreach ($items as &$item) {
+            $item['url'] = sprintf(
+                $item['url'],
+                $school->getId(),
+                $school->getSlug()
+            );
+        }
+
+        return $items;
+    }
+
+    private function setActiveItem(Request $request)
+    {
+        $pathInfo = $request->getPathInfo();
+        $lastSegmentFromRequest = $this->getLastUrlSegment($pathInfo);
+
+        foreach ($this->items as $key => $item) {
+            $lastSegmentFromMenuItem = $this->getLastUrlSegment($item['url']);
+
+            if ($lastSegmentFromRequest === $lastSegmentFromMenuItem) {
+                $this->items[$key]['isActive'] = true;
+            }
+        }
+    }
+}

--- a/src/AppBundle/Util/RequestSegmentTrait.php
+++ b/src/AppBundle/Util/RequestSegmentTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AppBundle\Util;
+
+trait RequestSegmentTrait
+{
+    private function getLastUrlSegment(string $pathInfo)
+    {
+        $urlSegments = explode('/', $pathInfo);
+        $lastUrlSegment = end($urlSegments);
+
+        return $lastUrlSegment;
+    }
+}

--- a/tests/fixture/Database/ProficiencyTableFixture.php
+++ b/tests/fixture/Database/ProficiencyTableFixture.php
@@ -2,10 +2,8 @@
 
 namespace Tests\Fixture\Database;
 
-class ProficiencyTableFixture
+class ProficiencyTableFixture extends ProvaBrasilDatabase
 {
-    private $entityManager;
-
     public function createTable($kernel)
     {
         $this->createDatabase($kernel);
@@ -15,38 +13,6 @@ class ProficiencyTableFixture
         $this->createProficiencyTable();
         $this->createDimRegionalAggregationTable();
         $this->createDimPoliticAggregationTable();
-    }
-
-    public function createDatabase($kernel)
-    {
-        $kernel->getContainer()
-            ->get('doctrine')
-            ->getManager()
-            ->getConnection()
-            ->prepare("CREATE DATABASE waitress_dw_prova_brasil_test;")
-            ->execute();
-    }
-
-    public function getEntityManager()
-    {
-        return $this->entityManager;
-    }
-
-    public function dropTable()
-    {
-        $this->entityManager->getConnection()
-            ->prepare("DROP DATABASE waitress_dw_prova_brasil_test;")
-            ->execute();
-
-        $this->entityManager->close();
-        $this->entityManager = null;
-    }
-
-    private function loadEntityManager($kernel)
-    {
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')
-            ->getManager('waitress_dw_prova_brasil');
     }
 
     public function populateWithBrazilRegister()

--- a/tests/fixture/Database/ProvaBrasilDatabase.php
+++ b/tests/fixture/Database/ProvaBrasilDatabase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Fixture\Database;
+
+abstract class ProvaBrasilDatabase
+{
+    protected $entityManager;
+
+    public function createDatabase($kernel)
+    {
+        $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getConnection()
+            ->prepare("CREATE DATABASE waitress_dw_prova_brasil_test;")
+            ->execute();
+    }
+
+    public function dropDatabase()
+    {
+        $this->entityManager->getConnection()
+            ->prepare("DROP DATABASE waitress_dw_prova_brasil_test;")
+            ->execute();
+    }
+
+    protected function loadEntityManager($kernel)
+    {
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager('waitress_dw_prova_brasil');
+    }
+
+    public function getEntityManager()
+    {
+        return $this->entityManager;
+    }
+
+    public function dropTable()
+    {
+        $this->dropDatabase();
+
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
+}

--- a/tests/fixture/Database/SchoolLearningTableFixture.php
+++ b/tests/fixture/Database/SchoolLearningTableFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Fixture\Database;
+
+class SchoolLearningTableFixture extends ProvaBrasilDatabase
+{
+    public function createTable($kernel)
+    {
+        $this->createDatabase($kernel);
+
+        $this->loadEntityManager($kernel);
+
+        $this->createSchoolLearningTable();
+    }
+
+    public function createSchoolLearningTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+CREATE TABLE `school` (
+  `id` int(10) unsigned NOT NULL,
+  `edition_id` tinyint(3) unsigned NOT NULL,
+  `state_id` tinyint(4) NOT NULL,
+  `city_id` smallint(6) NOT NULL,
+  `localization_id` tinyint(4) DEFAULT NULL,
+  `dependence_id` tinyint(4) DEFAULT NULL,
+  PRIMARY KEY (`id`,`edition_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+SQL
+            )->execute();
+    }
+
+    public function populateWithSchoolRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `school` (`id`, `edition_id`, `state_id`, `city_id`, `localization_id`, `dependence_id`)
+VALUES
+(258542, 6, 112, 2, 1, 2);
+SQL
+            )->execute();
+    }
+}

--- a/tests/integration/AppBundle/Repository/Learning/SchoolRepositoryTest.php
+++ b/tests/integration/AppBundle/Repository/Learning/SchoolRepositoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Integration\AppBundle\Repository\Learning;
+
+use AppBundle\Entity\Learning\School;
+use AppBundle\Learning\ProvaBrasilEdition;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Fixture\Database\SchoolLearningTableFixture;
+
+class SchoolRepositoryTest extends KernelTestCase
+{
+    private $schoolLearningTableFixture;
+    private $emSchool;
+
+    /**
+     * @dataProvider findSchoolProficiencyByEditionDataProvider
+     */
+    public function testFindSchoolProficiencyByEdition($school, $provaBrasilEdition, $resultExpected)
+    {
+        $result = $this->emSchool
+            ->getRepository(School::class)
+            ->findSchoolProficiencyByEdition($school, $provaBrasilEdition);
+
+        $this->assertEquals($resultExpected, count($result));
+    }
+
+    public function findSchoolProficiencyByEditionDataProvider()
+    {
+        return [
+            'with_school_learning' => [
+                $this->getSchoolMock(),
+                new ProvaBrasilEdition(6, 2015),
+                $schoolsFound = 1,
+            ],
+            'without_school_learning' => [
+                $this->getSchoolMock(),
+                new ProvaBrasilEdition(2, 2007),
+                $schoolsFound = 0,
+            ],
+        ];
+    }
+
+    private function getSchoolMock()
+    {
+        $schoolMock = $this->createMock('AppBundle\Entity\School');
+
+        $schoolMock->method('getId')
+            ->willReturn(258542);
+
+        return $schoolMock;
+    }
+
+    protected function setUp()
+    {
+        $kernel = self::bootKernel();
+
+        $this->schoolLearningTableFixture = new SchoolLearningTableFixture();
+        $this->schoolLearningTableFixture->createTable($kernel);
+        $this->schoolLearningTableFixture->populateWithSchoolRegister();
+
+        $this->emSchool = $this->schoolLearningTableFixture->getEntityManager();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->schoolLearningTableFixture->dropTable();
+    }
+}

--- a/tests/unit/AppBundle/Learning/SchoolProficiencyTest.php
+++ b/tests/unit/AppBundle/Learning/SchoolProficiencyTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\AppBundle\Learning;
+
+use AppBundle\Learning\SchoolProficiency;
+use PHPUnit\Framework\TestCase;
+
+class SchoolProficiencyTest extends TestCase
+{
+    /**
+     * @dataProvider hasProficiencyInLastEditionDataProvider
+     */
+    public function testHasProficiencyInLastEdition($repositoryResult, $expectedResult)
+    {
+        $schoolLearningRepository = $this->getSchoolLearningRepositoryMock($repositoryResult);
+        $provaBrasilService = $this->getProvaBrasilServiceMock();
+        $school = $this->getSchoolMock();
+
+        $schoolProficiency = new SchoolProficiency($schoolLearningRepository, $provaBrasilService);
+        $hasProficiencyInLastEdition = $schoolProficiency->hasProficiencyInLastEdition($school);
+
+        $this->assertEquals($expectedResult, $hasProficiencyInLastEdition);
+    }
+
+    public function hasProficiencyInLastEditionDataProvider()
+    {
+        return [
+            'without_proficiency' => [[], false],
+            'with_proficiency' => [[$this->getSchoolMock()], true],
+        ];
+    }
+
+    private function getSchoolLearningRepositoryMock($repositoryResult)
+    {
+        $schoolLearningRepositoryMock = $this->createMock('AppBundle\Repository\Learning\SchoolRepositoryInterface');
+        $schoolLearningRepositoryMock->method('findSchoolProficiencyByEdition')
+            ->with(
+                $this->getSchoolMock(),
+                $this->getProvaBrasilEditionMock()
+            )
+            ->willReturn($repositoryResult);
+
+        return $schoolLearningRepositoryMock;
+    }
+
+    private function getSchoolMock()
+    {
+        $schoolMock = $this->createMock('AppBundle\Entity\School');
+
+        return $schoolMock;
+    }
+
+    private function getProvaBrasilServiceMock()
+    {
+        $provaBrasilServiceMock = $this->createMock('AppBundle\Learning\ProvaBrasilService');
+
+        $provaBrasilServiceMock->method('getLastEdition')
+            ->willReturn($this->getProvaBrasilEditionMock());
+
+        return $provaBrasilServiceMock;
+    }
+
+    private function getProvaBrasilEditionMock()
+    {
+        $provaBrasilEditionMock = $this->createMock('AppBundle\Learning\ProvaBrasilEdition');
+
+        $provaBrasilEditionMock->method('getCode')
+            ->willReturn(6);
+
+        return $provaBrasilEditionMock;
+    }
+}

--- a/tests/unit/AppBundle/Util/BreadcrumbTest.php
+++ b/tests/unit/AppBundle/Util/BreadcrumbTest.php
@@ -12,8 +12,8 @@ class BreadcrumbTest extends TestCase
         $school = $this->getSchoolMock();
         $request = $this->getRequestMock();
 
-        $breadcrumb = new Breadcrumb($school, $request);
-        $items = $breadcrumb->getItems();
+        $breadcrumb = new Breadcrumb();
+        $items = $breadcrumb->buildItems($school, $request);
 
         $itemsExpected = $this->getSchoolItemsExpected();
 

--- a/tests/unit/AppBundle/Util/MenuBuilderTest.php
+++ b/tests/unit/AppBundle/Util/MenuBuilderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Unit\AppBundle\Util;
+
+use AppBundle\Util\MenuBuilder;
+use PHPUnit\Framework\TestCase;
+
+class MenuBuilderTest extends TestCase
+{
+    /**
+     * @dataProvider menuWithoutLearningSectionDataProvider
+     */
+    public function testBuildShouldReturnItemsWithoutLearningSection($itemsExpected)
+    {
+        $schoolProficiency = $this->getSchoolProficiencyMockWithoutProficiency();
+        $request = $this->getRequestMockFromAboutUrl();
+        $school = $this->getSchoolMock();
+
+        $menu = new MenuBuilder($schoolProficiency);
+        $items = $menu->buildItems($school, $request);
+
+        $this->assertEquals(count($itemsExpected), count($items));
+        $this->assertEquals($itemsExpected, $items);
+    }
+
+    public function menuWithoutLearningSectionDataProvider()
+    {
+        return [
+            [
+                [
+                    [
+                        'name' => 'Sobre a Escola',
+                        'url' => '/escola/156485-ee-belmiro-braga/sobre',
+                        'icon' => 'icon-page-about',
+                        'isActive' => true,
+                    ],
+                    [
+                        'name' => 'Enem',
+                        'url' => '/escola/156485-ee-belmiro-braga/enem',
+                        'icon' => 'icon-page-enem',
+                        'isActive' => false,
+                    ],
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider menuWithLearningSectionDataProvider
+     */
+    public function testBuildShouldReturnItemsWithLearningSection($itemsExpected)
+    {
+        $schoolProficiency = $this->getSchoolProficiencyMockWithProficiency();
+        $request = $this->getRequestMockFromCensusUrl();
+        $school = $this->getSchoolMock();
+
+        $menu = new MenuBuilder($schoolProficiency);
+        $items = $menu->buildItems($school, $request);
+
+        $this->assertEquals(count($itemsExpected), count($items));
+        $this->assertEquals($itemsExpected, $items);
+    }
+
+    public function menuWithLearningSectionDataProvider()
+    {
+        return [
+            [
+                [
+                    [
+                        'name' => 'Aprendizado',
+                        'url' => '/escola/156485-ee-belmiro-braga/aprendizado',
+                        'icon' => 'icon-page-learning',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Compare',
+                        'url' => '/escola/156485-ee-belmiro-braga/compare',
+                        'icon' => 'icon-page-compare',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Evolução',
+                        'url' => '/escola/156485-ee-belmiro-braga/evolucao',
+                        'icon' => 'icon-page-evolution',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Proficiência',
+                        'url' => '/escola/156485-ee-belmiro-braga/proficiencia',
+                        'icon' => 'icon-page-proficiency',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Explore',
+                        'url' => '/escola/156485-ee-belmiro-braga/explorar',
+                        'icon' => 'icon-page-explore',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Pessoas',
+                        'url' => '/escola/156485-ee-belmiro-braga/pessoas',
+                        'icon' => 'icon-page-director',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Censo',
+                        'url' => '/escola/156485-ee-belmiro-braga/censo-escolar',
+                        'icon' => 'icon-page-census',
+                        'isActive' => true,
+                    ],
+                    [
+                        'name' => 'Ideb',
+                        'url' => '/escola/156485-ee-belmiro-braga/ideb',
+                        'icon' => 'icon-page-ideb',
+                        'isActive' => false,
+                    ],
+                    [
+                        'name' => 'Enem',
+                        'url' => '/escola/156485-ee-belmiro-braga/enem',
+                        'icon' => 'icon-page-enem',
+                        'isActive' => false,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function getSchoolProficiencyMockWithoutProficiency()
+    {
+        $schoolProficiencyInterfaceMock = $this->createMock('AppBundle\Learning\ProficiencyInterface');
+        $schoolProficiencyInterfaceMock->method('hasProficiencyInLastEdition')
+            ->with($this->getSchoolMock())
+            ->willReturn(false);
+
+        return $schoolProficiencyInterfaceMock;
+    }
+
+    private function getSchoolProficiencyMockWithProficiency()
+    {
+        $schoolProficiencyInterfaceMock = $this->createMock('AppBundle\Learning\ProficiencyInterface');
+        $schoolProficiencyInterfaceMock->method('hasProficiencyInLastEdition')
+            ->with($this->getSchoolMock())
+            ->willReturn(true);
+
+        return $schoolProficiencyInterfaceMock;
+    }
+
+    private function getRequestMockFromAboutUrl()
+    {
+        $requestMock = $this->createMock('Symfony\Component\HttpFoundation\Request');
+
+        $requestMock->method('getPathInfo')
+            ->willReturn('/escola/156485-ee-belmiro-braga/sobre');
+
+        return $requestMock;
+    }
+
+    private function getRequestMockFromCensusUrl()
+    {
+        $requestMock = $this->createMock('Symfony\Component\HttpFoundation\Request');
+
+        $requestMock->method('getPathInfo')
+            ->willReturn('/escola/156485-ee-belmiro-braga/censo-escolar');
+
+        return $requestMock;
+    }
+
+    private function getSchoolMock()
+    {
+        $schoolMock = $this->createMock('AppBundle\Entity\School');
+
+        $schoolMock->method('getId')
+            ->willReturn(156485);
+
+        $schoolMock->method('getSlug')
+            ->willReturn('ee-belmiro-braga');
+
+        return $schoolMock;
+    }
+}


### PR DESCRIPTION
## Description

Add dynamic menu in school pages.

- Add MenuBuilder class and tests.
- Add others classes and refactor to add menu business rules.
    - In school pages we have two menu presentations possible.
        - If school has proficiency data we have a complete menu version.
        - If school has **not** proficiency data we have a compact menu version `(About school and Enem sections only)`

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub

Migration of about school page.

## Screenshot

#### Compact version
![screen shot 2018-05-28 at 12 18 24 pm](https://user-images.githubusercontent.com/1117674/40620981-52526600-6271-11e8-80fa-0b52e72f7f64.png)
#### Complete version
![screen shot 2018-05-28 at 12 18 44 pm](https://user-images.githubusercontent.com/1117674/40620982-5274937e-6271-11e8-9366-f428f01b007f.png)
