### PR TITLE
Add census filter

### DIFF
--- a/app/Resources/views/census/school.html.twig
+++ b/app/Resources/views/census/school.html.twig
@@ -8,6 +8,59 @@
 
 {% block body %}
   {% include 'census/subnav.html.twig' %}
+  <section class="container censo-section normal-section">
+    <div class="row">
+      <div class="span12">
+        <h2>Matrículas e Infraestrutura</h2>
+      </div>
+
+      <div class="span12" id="ujeid_0">
+        <div class="census-ct row-fluid" id="ujeid_6">
+          <div class="census-filter buttons-census-filter-area">
+            <label class="pull-left census-label" for="year">Ano:</label>
+            <div class="btn-group census-btn" id="year">
+
+              <a class="btn dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+                <span class="button-census-filter-value">{{ filter.getCurrentYear() }}</span>
+                <span class="caret"></span>
+              </a>
+
+              {% set listClass = filter.isBlocked() ? 'dropdown-menu-blocked' : ''  %}
+              {% set itemClass = filter.isBlocked() ? 'disabled' : 'enabled'  %}
+
+              <ul class="dropdown-menu census-drop {{ listClass }}">
+
+                {% for year in filter.getYears() %}
+
+                  {% set activeYearClass = filter.getCurrentYear() == year and not filter.isBlocked() ? 'active' : '' %}
+
+                  <li class="{{ itemClass }} {{ activeYearClass }}">
+                    <a data-reload="1" data-value="{{ year }}" data-filter="year" class="census-link">{{ year }}</a>
+                  </li>
+                {% endfor %}
+
+                {% if filter.isBlocked() %}
+                  <div class="content-alert">
+                    <div class="main-phrase">
+                      Recurso exclusivo e gratuito do QEdu<br>Cadastre-se para obter acesso
+                    </div>
+                    <div class="main-links">
+                      <a href="/cadastrar" class="signup">Cadastrar</a>
+                      <span class="alert-divider">ou</span>
+                      <a href="/entrar" class="signin">Entrar</a>
+                    </div>
+                  </div>
+                {% endif %}
+
+              </ul>
+
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
 {% endblock %}
 
 {% block stylesheets %}
@@ -20,6 +73,13 @@
   <script type="text/javascript" src="/gimme/2a854d73fb/pkg/js/QEdu/Header.js"></script>
   <script type="text/javascript" src="/gimme/f46964a241/pkg/js/select2-lib.js"></script>
   <script type="text/javascript" src="/gimme/85d63f33ed/pkg/js/provabrasil/dropdown-select2.js"></script>
+  <script type="text/javascript" src="/gimme/03e82aef14/pkg/js/mcc-basic-libs.js"></script>
+  <script type="text/javascript" src="/gimme/08f65bba69/js/provabrasil/censo/view-item.js"></script>
+  <script type="text/javascript" src="/gimme/9babdd66de/js/provabrasil/censo/model-item.js"></script>
+  <script type="text/javascript" src="/gimme/bd09500298/js/provabrasil/censo/model-raw_data_censo.js"></script>
+  <script type="text/javascript" src="/gimme/fd5e5451f7/js/provabrasil/censo/view-buttons_filter_censo.js"></script>
+  <script type="text/javascript" src="/gimme/d9d89cd771/js/provabrasil/censo/behavior-filter.js"></script>
+  <script type="text/javascript" src="/gimme/e2921f29b8/pkg/js/jquery.libs.js"></script>
   <script type="text/javascript">
     mcc.init_behaviors({
         "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}],
@@ -41,7 +101,18 @@
               },
             {% endfor %}
 
-        ]
+        ],
+        "provabrasil-behavior-censo-filter":[{
+            "filter_id":"ujeid_6",
+            "results":[],
+            "defaultIndex":"index-0-0-1-0",
+            "availableFilters":["year"],
+            "defaultFields":{
+                "dependence":0,
+                "localization":0,
+                "education_stage":0
+            }
+        }]
     });
   </script>
 {% endblock %}

--- a/app/Resources/views/census/subnav.html.twig
+++ b/app/Resources/views/census/subnav.html.twig
@@ -41,5 +41,16 @@
     </ul>
   </div>
 </section>
+<section class="subnav-detail-section subnav-detail-section-menu">
+  <div class="container">
+    <div class="subnav-detail clearfix with-avatar-small-margin">
+      <ul class="nav nav-pills">
+        <li class="active"><a href="/escola/{{ school.getId() }}-{{ school.getSlug() }}/censo-escolar">Matrículas e Infraestrutura</a></li>
+        <li class=""><a href="/escola/{{ school.getId() }}-{{ school.getSlug() }}/taxas-rendimento">Taxas de Rendimento</a></li>
+        <li class=""><a href="/escola/{{ school.getId() }}-{{ school.getSlug() }}/distorcao-idade-serie">Distorção Idade-Série</a></li>
+      </ul>
+    </div>
+  </div>
+</section>
 
 <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-542c488254cb45ee" async></script>

--- a/composer.lock
+++ b/composer.lock
@@ -2154,37 +2154,38 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.3.14",
+            "version": "v3.3.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "8e2b473de636a65a018b370d5e88778a260f0e33"
+                "reference": "4639525c796227ec36652ad97192a5eb3de74f76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/8e2b473de636a65a018b370d5e88778a260f0e33",
-                "reference": "8e2b473de636a65a018b370d5e88778a260f0e33",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/4639525c796227ec36652ad97192a5eb3de74f76",
+                "reference": "4639525c796227ec36652ad97192a5eb3de74f76",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "~2.4",
+                "ext-xml": "*",
                 "fig/link-util": "^1.0",
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/cache": "~1.0",
                 "psr/container": "^1.0",
                 "psr/link": "^1.0",
                 "psr/log": "~1.0",
                 "psr/simple-cache": "^1.0",
+                "symfony/polyfill-apcu": "~1.1",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php56": "~1.0",
                 "symfony/polyfill-php70": "~1.0",
-                "symfony/polyfill-util": "~1.0",
-                "twig/twig": "~1.32|~2.2"
+                "twig/twig": "~1.34|~2.4"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "<3.0",
-                "phpdocumentor/type-resolver": "<0.2.0",
+                "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.2.1",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "provide": {
@@ -2246,6 +2247,7 @@
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
+                "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.6",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
@@ -2254,11 +2256,10 @@
                 "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-                "phpdocumentor/reflection-docblock": "^3.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
                 "predis/predis": "~1.0",
                 "sensio/framework-extra-bundle": "^3.0.2",
-                "symfony/phpunit-bridge": "~3.2",
-                "symfony/polyfill-apcu": "~1.1",
+                "symfony/phpunit-bridge": "~3.4|~4.0",
                 "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
@@ -2272,7 +2273,6 @@
                     "Symfony\\Bridge\\Doctrine\\": "src/Symfony/Bridge/Doctrine/",
                     "Symfony\\Bridge\\Monolog\\": "src/Symfony/Bridge/Monolog/",
                     "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
-                    "Symfony\\Bridge\\Swiftmailer\\": "src/Symfony/Bridge/Swiftmailer/",
                     "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
                     "Symfony\\Bundle\\": "src/Symfony/Bundle/",
                     "Symfony\\Component\\": "src/Symfony/Component/"
@@ -2303,7 +2303,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-05-29T21:02:32+00:00"
+            "time": "2018-05-25T12:43:13+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/AppBundle/Census/CensusFilter.php
+++ b/src/AppBundle/Census/CensusFilter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AppBundle\Census;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class CensusFilter
+{
+    private $authorizationChecker;
+    private $request;
+    private $defaultYear = 2017;
+    private $years = [
+        2017,
+        2016,
+        2015,
+        2014,
+        2013,
+        2012,
+        2011,
+        2010,
+    ];
+
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, RequestStack $request)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+        $this->request = $request;
+    }
+
+    public function isBlocked()
+    {
+        return $this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY') === false;
+    }
+
+    public function getYears()
+    {
+        return $this->years;
+    }
+
+    public function getCurrentYear()
+    {
+        return $this->request->getCurrentRequest()->get('year', $this->defaultYear);
+    }
+}

--- a/src/AppBundle/Controller/CensusController.php
+++ b/src/AppBundle/Controller/CensusController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Census\CensusFilter;
 use AppBundle\Util\Breadcrumb;
 use AppBundle\Util\MenuBuilder;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -12,11 +13,13 @@ class CensusController extends Controller
 {
     private $breadcrumb;
     private $menuBuilder;
+    private $censusFilter;
 
-    public function __construct(Breadcrumb $breadcrumb, MenuBuilder $menuBuilder)
+    public function __construct(Breadcrumb $breadcrumb, MenuBuilder $menuBuilder, CensusFilter $censusFilter)
     {
         $this->breadcrumb = $breadcrumb;
         $this->menuBuilder = $menuBuilder;
+        $this->censusFilter = $censusFilter;
     }
 
     /**
@@ -41,6 +44,7 @@ class CensusController extends Controller
             'school' => $school,
             'breadcrumbItems' => $breadcrumbItems,
             'menuItems' => $menuItems,
+            'filter' => $this->censusFilter,
         ]);
     }
 }

--- a/tests/unit/AppBundle/Census/CensusFilterTest.php
+++ b/tests/unit/AppBundle/Census/CensusFilterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit\AppBundle\Census;
+
+use AppBundle\Census\CensusFilter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class CensusFilterTest extends TestCase
+{
+    public function testIsBlockedShouldReturnFalseWhenUserIsLogged()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMockWhenUserIsLogged();
+        $request = $this->createRequestStackMock();
+
+        $filter = new CensusFilter($authorizationChecker, $request);
+
+        $this->assertFalse($filter->isBlocked());
+    }
+
+    public function testIsBlockedShouldReturnTrueWhenUserIsNotLogged()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMockWhenUserIsNotLogged();
+        $request = $this->createRequestStackMock();
+
+        $filter = new CensusFilter($authorizationChecker, $request);
+
+        $this->assertTrue($filter->isBlocked());
+    }
+
+    public function testGetYearsShouldReturnYearsAvailable()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMock();
+        $request = $this->createRequestStackMock();
+
+        $filter = new CensusFilter($authorizationChecker, $request);
+
+        $expectedYears = [
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+        ];
+
+        $this->assertEquals($expectedYears, $filter->getYears());
+    }
+
+    public function testGetCurrentYearShouldReturnDefaultYear()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMock();
+        $request = $this->createRequestStackWithoutQueryString();
+
+        $filter = new CensusFilter($authorizationChecker, $request);
+
+        $defaultYearExpected = 2017;
+
+        $this->assertEquals($defaultYearExpected, $filter->getCurrentYear());
+    }
+
+    public function testGetCurrentYearShouldReturnYearBasedOnRequest()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMock();
+        $request = $this->createRequestStackWithYearSettledInQueryString();
+
+        $filter = new CensusFilter($authorizationChecker, $request);
+
+        $yearExpected = 2011;
+
+        $this->assertEquals($yearExpected, $filter->getCurrentYear());
+    }
+
+    private function createAuthorizationCheckerMockWhenUserIsLogged()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMock();
+
+        $authorizationChecker->method('isGranted')
+            ->with('IS_AUTHENTICATED_FULLY')
+            ->willReturn(true);
+
+        return $authorizationChecker;
+    }
+
+    private function createAuthorizationCheckerMockWhenUserIsNotLogged()
+    {
+        $authorizationChecker = $this->createAuthorizationCheckerMock();
+
+        $authorizationChecker->method('isGranted')
+            ->with('IS_AUTHENTICATED_FULLY')
+            ->willReturn(false);
+
+        return $authorizationChecker;
+    }
+
+    private function createAuthorizationCheckerMock()
+    {
+        return $this->createMock(AuthorizationCheckerInterface::class);
+    }
+
+    private function createRequestStackWithoutQueryString()
+    {
+        $requestMock = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $requestMock->method('get')
+            ->with('year', $defaultYear = 2017)
+            ->willReturn($defaultYear);
+
+        $requestStackMock = $this->createRequestStackMock();
+        $requestStackMock->method('getCurrentRequest')
+            ->willReturn($requestMock);
+
+        return $requestStackMock;
+    }
+
+    private function createRequestStackWithYearSettledInQueryString()
+    {
+        $requestMock = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $requestMock->method('get')
+            ->with('year', $defaultYear = 2017)
+            ->willReturn($selectedYear = 2011);
+
+        $requestStackMock = $this->createRequestStackMock();
+        $requestStackMock->method('getCurrentRequest')
+            ->willReturn($requestMock);
+
+        return $requestStackMock;
+    }
+
+    public function createRequestStackMock()
+    {
+        return $this->createMock('Symfony\Component\HttpFoundation\RequestStack');
+    }
+}


### PR DESCRIPTION
## Description

Add census filter in school pages.

- Add `CensusFilter` class and tests.
- Add census filter in `CensusController`.
- Update views.
- Update **Symfony patch version** from 3.3.14 to 3.3.10.

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub

Migration of about school page.

## Screenshot

#### Logged

<img width="980" alt="screen shot 2018-05-31 at 7 02 32 pm" src="https://user-images.githubusercontent.com/1117674/40810766-3a1cd2b4-6505-11e8-8cf2-2c84f402c03f.png">


#### Not Logged

<img width="973" alt="screen shot 2018-05-31 at 6 57 45 pm" src="https://user-images.githubusercontent.com/1117674/40810732-1b49711c-6505-11e8-843c-2a402b26831a.png">

