### PR TITLE
Replace census school route

### DIFF
--- a/src/AppBundle/Controller/CensusController.php
+++ b/src/AppBundle/Controller/CensusController.php
@@ -23,7 +23,7 @@ class CensusController extends Controller
      *     requirements={
      *         "schoolId": "\d+",
      *         "schoolSlug": ".*",
-     *         "section": "(sobre|censo-escolar-dev)"
+     *         "section": "(sobre|censo-escolar)"
      *     }
      * )
      */


### PR DESCRIPTION
## Description

Replace development route(`censo-escolar-dev`) to original census school route(`censo-escolar`).

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub


