### PR TITLE
Render school learning content

### DIFF
--- a/app/Resources/views/learning/content.html.twig
+++ b/app/Resources/views/learning/content.html.twig
@@ -26,24 +26,26 @@
 
 <section class="normal-section didactic-section container">
 
-  <div class="container-db-filters">
-    <div class="didactic-block-filters row">
-      <div class="btn-group db-filters span12">
-      <ul class="nav first pull-left">
-        <li class="active">Informações sobre:</li>
-      </ul>
-      <ul class="nav nav-pills pull-left">
-        <li><a href="#" data-value="0" data-filter="dependence">Todas</a></li>
-        <li><a href="#" data-value="3" data-filter="dependence">Escolas Municipais</a></li>
-        <li><a href="#" data-value="2" data-filter="dependence">Escolas Estaduais</a></li>
-      </ul>
+  {% if school is not defined %}
+    <div class="container-db-filters">
+      <div class="didactic-block-filters row">
+        <div class="btn-group db-filters span12">
+        <ul class="nav first pull-left">
+          <li class="active">Informações sobre:</li>
+        </ul>
+        <ul class="nav nav-pills pull-left">
+          <li><a href="#" data-value="0" data-filter="dependence">Todas</a></li>
+          <li><a href="#" data-value="3" data-filter="dependence">Escolas Municipais</a></li>
+          <li><a href="#" data-value="2" data-filter="dependence">Escolas Estaduais</a></li>
+        </ul>
+        </div>
       </div>
     </div>
-  </div>
+  {% endif %}
 
   <div class="didactic-block row">
     <div class="span7" id="state-100">
-      {% for learning in brazilLearning  %}
+      {% for learning in learnings  %}
 
         {% set lastElementClass = loop.last ? 'didactic-block-last' %}
 

--- a/app/Resources/views/learning/school.html.twig
+++ b/app/Resources/views/learning/school.html.twig
@@ -20,6 +20,8 @@
 
 {% block body %}
   {% include 'subnav.html.twig' %}
+  {% include 'learning/content.html.twig' %}
+  {% include 'learning/banner.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -40,7 +40,7 @@ class LearningController extends Controller
 
         return $this->render('learning/brazil.html.twig', [
             'provaBrasilEdition' => $this->provaBrasilLastEdition,
-            'brazilLearning' => $brazilLearning,
+            'learnings' => $brazilLearning,
         ]);
     }
 
@@ -90,7 +90,7 @@ class LearningController extends Controller
                 'header' => $this->header,
                 'school' => $school,
                 'provaBrasilEdition' => $this->provaBrasilLastEdition,
-                'schoolLearning' => $this->schoolLearningPage->getSchoolLearning(),
+                'learnings' => $this->schoolLearningPage->getSchoolLearning(),
             ]);
         } catch (SchoolNotFoundException | SchoolLearningNotFoundException $exception) {
             throw new NotFoundHttpException($exception);

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -7,7 +7,7 @@ use AppBundle\Exception\SchoolLearningNotFoundException;
 use AppBundle\Exception\SchoolNotFoundException;
 use AppBundle\Learning\LearningService;
 use AppBundle\Learning\ProvaBrasilService;
-use AppBundle\Learning\SchoolLearningPage;
+use AppBundle\Learning\SchoolLearningContent;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -16,18 +16,18 @@ class LearningController extends Controller
 {
     private $provaBrasilLastEdition;
     private $learningService;
-    private $schoolLearningPage;
+    private $schoolLearningContent;
     private $header;
 
     public function __construct(
         ProvaBrasilService $provaBrasilService,
         LearningService $learningService,
-        SchoolLearningPage $schoolLearningPage,
+        SchoolLearningContent $schoolLearningContent,
         Header $header
     ) {
         $this->provaBrasilLastEdition = $provaBrasilService->getLastEdition();
         $this->learningService = $learningService;
-        $this->schoolLearningPage = $schoolLearningPage;
+        $this->schoolLearningContent = $schoolLearningContent;
         $this->header = $header;
     }
 
@@ -56,12 +56,12 @@ class LearningController extends Controller
     public function ampSchoolAction(int $schoolId)
     {
         try {
-            $this->schoolLearningPage->build($schoolId, $this->provaBrasilLastEdition);
+            $this->schoolLearningContent->build($schoolId, $this->provaBrasilLastEdition);
 
             return $this->render('learning/amp/school.html.twig', [
-                'school' => $this->schoolLearningPage->getSchool(),
+                'school' => $this->schoolLearningContent->getSchool(),
                 'provaBrasilEdition' => $this->provaBrasilLastEdition,
-                'schoolLearning' => $this->schoolLearningPage->getSchoolLearning(),
+                'schoolLearning' => $this->schoolLearningContent->getSchoolLearning(),
             ]);
         } catch (SchoolNotFoundException | SchoolLearningNotFoundException $exception) {
             throw new NotFoundHttpException($exception);
@@ -80,9 +80,9 @@ class LearningController extends Controller
     public function schoolAction(int $schoolId)
     {
         try {
-            $this->schoolLearningPage->build($schoolId, $this->provaBrasilLastEdition);
+            $this->schoolLearningContent->build($schoolId, $this->provaBrasilLastEdition);
 
-            $school =  $this->schoolLearningPage->getSchool();
+            $school =  $this->schoolLearningContent->getSchool();
 
             $this->header->build($school);
 
@@ -90,7 +90,7 @@ class LearningController extends Controller
                 'header' => $this->header,
                 'school' => $school,
                 'provaBrasilEdition' => $this->provaBrasilLastEdition,
-                'learnings' => $this->schoolLearningPage->getSchoolLearning(),
+                'learnings' => $this->schoolLearningContent->getSchoolLearning(),
             ]);
         } catch (SchoolNotFoundException | SchoolLearningNotFoundException $exception) {
             throw new NotFoundHttpException($exception);

--- a/src/AppBundle/Entity/Census/School.php
+++ b/src/AppBundle/Entity/Census/School.php
@@ -150,19 +150,9 @@ class School
         return $this->stateId;
     }
 
-    public function setStateId(int $stateId)
-    {
-        $this->stateId = $stateId;
-    }
-
     public function getCityId(): int
     {
         return $this->cityId;
-    }
-
-    public function setCityId(int $cityId)
-    {
-        $this->cityId = $cityId;
     }
 
     public function getSchoolId(): int
@@ -170,19 +160,9 @@ class School
         return $this->schoolId;
     }
 
-    public function setSchoolId(int $schoolId)
-    {
-        $this->schoolId = $schoolId;
-    }
-
     public function getEducacenso(): int
     {
         return $this->educacenso;
-    }
-
-    public function setEducacenso(int $educacenso)
-    {
-        $this->educacenso = $educacenso;
     }
 
     public function hasProvaBrasil(): bool
@@ -193,11 +173,6 @@ class School
     public function getFaxNumber(): ?int
     {
         return $this->faxNumber;
-    }
-
-    public function setFaxNumber(?int $faxNumber)
-    {
-        $this->faxNumber = $faxNumber;
     }
 
     public function getAccessibility(): Accessibility

--- a/src/AppBundle/Entity/DimRegionalAggregation.php
+++ b/src/AppBundle/Entity/DimRegionalAggregation.php
@@ -72,19 +72,9 @@ class DimRegionalAggregation
         return $this->stateId;
     }
 
-    public function setStateId(int $stateId)
-    {
-        $this->stateId = $stateId;
-    }
-
     public function getCityId(): int
     {
         return $this->cityId;
-    }
-
-    public function setCityId(int $cityId)
-    {
-        $this->cityId = $cityId;
     }
 
     public function getSchoolId(): int
@@ -92,28 +82,13 @@ class DimRegionalAggregation
         return $this->schoolId;
     }
 
-    public function setSchoolId(int $schoolId)
-    {
-        $this->schoolId = $schoolId;
-    }
-
     public function getTeamId(): int
     {
         return $this->teamId;
     }
 
-    public function setTeamId(int $teamId)
-    {
-        $this->teamId = $teamId;
-    }
-
     public function getCityGroupId(): int
     {
         return $this->cityGroupId;
-    }
-
-    public function setCityGroupId(int $cityGroupId)
-    {
-        $this->cityGroupId = $cityGroupId;
     }
 }

--- a/src/AppBundle/Entity/Learning/School.php
+++ b/src/AppBundle/Entity/Learning/School.php
@@ -75,19 +75,9 @@ class School
         return $this->editionId;
     }
 
-    public function setEditionId(int $editionId)
-    {
-        $this->editionId = $editionId;
-    }
-
     public function getStateId(): int
     {
         return $this->stateId;
-    }
-
-    public function setStateId(int $stateId)
-    {
-        $this->stateId = $stateId;
     }
 
     public function getCityId(): int
@@ -95,28 +85,13 @@ class School
         return $this->cityId;
     }
 
-    public function setCityId(int $cityId)
-    {
-        $this->cityId = $cityId;
-    }
-
     public function getLocalizationId(): int
     {
         return $this->localizationId;
     }
 
-    public function setLocalizationId(int $localizationId)
-    {
-        $this->localizationId = $localizationId;
-    }
-
     public function getDependenceId(): int
     {
         return $this->dependenceId;
-    }
-
-    public function setDependenceId(int $dependenceId)
-    {
-        $this->dependenceId = $dependenceId;
     }
 }

--- a/src/AppBundle/Learning/SchoolLearningContent.php
+++ b/src/AppBundle/Learning/SchoolLearningContent.php
@@ -8,7 +8,7 @@ use AppBundle\Exception\SchoolNotFoundException;
 use AppBundle\Repository\SchoolRepositoryInterface;
 use AppBundle\Repository\Learning\SchoolRepositoryInterface as SchoolLearningRepositoryInterface;
 
-class SchoolLearningPage
+class SchoolLearningContent
 {
     private $schoolRepository;
     private $school;

--- a/tests/unit/AppBundle/Learning/SchoolLearningContentTest.php
+++ b/tests/unit/AppBundle/Learning/SchoolLearningContentTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit\AppBundle\Learning;
 
-use AppBundle\Learning\SchoolLearningPage;
+use AppBundle\Learning\SchoolLearningContent;
 use PHPUnit\Framework\TestCase;
 
-class SchoolLearningPageTest extends TestCase
+class SchoolLearningContentTest extends TestCase
 {
     public function testBuildShouldSchoolAndLearning()
     {
@@ -41,15 +41,15 @@ class SchoolLearningPageTest extends TestCase
             )
             ->willReturn($schoolLearning);
 
-        $schoolLearningPage = new SchoolLearningPage(
+        $schoolLearningContent = new SchoolLearningContent(
             $schoolRepository,
             $schoolLearningRepository,
             $learningService
         );
-        $schoolLearningPage->build($schoolId, $provaBrasilEdition);
+        $schoolLearningContent->build($schoolId, $provaBrasilEdition);
 
-        $this->assertInstanceOf('AppBundle\Entity\School', $schoolLearningPage->getSchool());
-        $this->assertEquals($schoolLearning, $schoolLearningPage->getSchoolLearning());
+        $this->assertInstanceOf('AppBundle\Entity\School', $schoolLearningContent->getSchool());
+        $this->assertEquals($schoolLearning, $schoolLearningContent->getSchoolLearning());
     }
 
     /**
@@ -69,12 +69,12 @@ class SchoolLearningPageTest extends TestCase
 
         $learningService = $this->createMock('AppBundle\Learning\learningService');
 
-        $schoolLearningPage = new SchoolLearningPage(
+        $schoolLearningContent = new SchoolLearningContent(
             $schoolRepository,
             $schoolLearningRepository,
             $learningService
         );
-        $schoolLearningPage->build($schoolId, $provaBrasilEdition);
+        $schoolLearningContent->build($schoolId, $provaBrasilEdition);
     }
 
     /**
@@ -102,11 +102,11 @@ class SchoolLearningPageTest extends TestCase
 
         $learningService = $this->createMock('AppBundle\Learning\learningService');
 
-        $schoolLearningPage = new SchoolLearningPage(
+        $schoolLearningContent = new SchoolLearningContent(
             $schoolRepository,
             $schoolLearningRepository,
             $learningService
         );
-        $schoolLearningPage->build($schoolId, $provaBrasilEdition);
+        $schoolLearningContent->build($schoolId, $provaBrasilEdition);
     }
 }


### PR DESCRIPTION
## Description

- Render `school learning content`.
- Remove unused setters in: Entity/Learning/School, Entity/DimRegionalAggregation, Entity/Census/School.
- Rename SchoolLearningPage to SchoolLearningContent

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub

Migration of school learning page.

## Screenshot

![screen shot 2018-07-27 at 7 39 10 pm](https://user-images.githubusercontent.com/1117674/43349241-dd1bade0-91d4-11e8-90f5-a1be12ab27b2.png)

