### PR TITLE
Enable to prod school learning page

### DIFF
--- a/app/Resources/views/learning/content.html.twig
+++ b/app/Resources/views/learning/content.html.twig
@@ -61,7 +61,7 @@
           <h3>{{ discipline }}, {{ gradeId }}º ano</h3>
 
 
-          <div class="qualitative-square optimal-decile-bg-{{ learning.getPercentage()|first }}">
+          <div class="qualitative-square {{ learning.getPercentage()|proficiencyCssClass }}">
               <span class="percent-level-with-data">
                 <span class="percent-level">{{ learning.getPercentage() }}</span>%
               </span>

--- a/app/Resources/views/learning/school.html.twig
+++ b/app/Resources/views/learning/school.html.twig
@@ -36,7 +36,8 @@
   <script type="text/javascript">
       mcc.init_behaviors({
           "Meritt\/QEdu\/UI\/Header\/Assets\/js\/GlobalSearchBehavior": [{"urlToAppend": ""}],
-
+          "provabrasil-behavior-util-tooltip": [{"all": true}],
+          "provabrasil-behavior-util-popover": [[]],
           "behavior-dropdown-select2":[
 
             {% for item in breadcrumb if item['type'] != 'country' %}

--- a/src/AppBundle/Controller/LearningController.php
+++ b/src/AppBundle/Controller/LearningController.php
@@ -69,7 +69,7 @@ class LearningController extends Controller
     }
 
     /**
-     * @Route("/escola/{schoolId}-{schoolSlug}/aprendizado-dev",
+     * @Route("/escola/{schoolId}-{schoolSlug}/aprendizado",
      *     name="learning_school",
      *     requirements={
      *         "schoolId": "\d+",

--- a/tests/functional/AppBundle/Controller/LearningControllerTest.php
+++ b/tests/functional/AppBundle/Controller/LearningControllerTest.php
@@ -3,15 +3,19 @@
 namespace Tests\Functional\AppBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Fixture\Database\CityTableFixture;
 use Tests\Fixture\Database\ProficiencyTableFixture;
 use Tests\Fixture\Database\SchoolTableFixture;
 use Tests\Fixture\Database\SchoolLearningTableFixture;
+use Tests\Fixture\Database\StateTableFixture;
 
 class LearningControllerTest extends WebTestCase
 {
     private $proficiencyTableFixture;
     private $schoolTableFixture;
     private $schoolLearningTableFixture;
+    private $stateTableFixture;
+    private $cityTableFixture;
 
     public function testExistentAMPSchoolPage()
     {
@@ -35,6 +39,28 @@ class LearningControllerTest extends WebTestCase
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
     }
 
+    public function testExistentSchoolPage()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/escola/142950-em-fazenda-aguas-verdes/aprendizado');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertContains('Português, 9º ano', $crawler->filter('.proficiency-9-1 h3')->text());
+        $this->assertContains('34', $crawler->filter('.proficiency-9-1 .percent-level')->text());
+        $this->assertContains('37', $crawler->filter('.proficiency-9-1 .present_count')->text());
+        $this->assertContains('12', $crawler->filter('.proficiency-9-1 .optimal_count')->text());
+    }
+
+    public function testNonExistentSchoolPage()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/escola/9999999-non-existent/aprendizado');
+
+        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+    }
+
     protected function setUp()
     {
         $kernel = self::bootKernel();
@@ -46,6 +72,16 @@ class LearningControllerTest extends WebTestCase
         $this->schoolTableFixture = new SchoolTableFixture();
         $this->schoolTableFixture->createTable($kernel);
         $this->schoolTableFixture->populateWithSchoolRegister();
+
+        $this->stateTableFixture = new StateTableFixture();
+        $this->stateTableFixture->loadEntityManager($kernel);
+        $this->stateTableFixture->createStateTable();
+        $this->stateTableFixture->populateWithStateRegister();
+
+        $this->cityTableFixture = new CityTableFixture();
+        $this->cityTableFixture->loadEntityManager($kernel);
+        $this->cityTableFixture->createCityTable();
+        $this->cityTableFixture->populateWithCityRegister();
 
         $this->schoolLearningTableFixture = new SchoolLearningTableFixture();
         $this->schoolLearningTableFixture->loadEntityManager($kernel);

--- a/tests/unit/AppBundle/Controller/EbookControllerTest.php
+++ b/tests/unit/AppBundle/Controller/EbookControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\AppBundle\Controller;
+
+use AppBundle\Controller\EbookController;
+use PHPUnit\Framework\TestCase;
+
+class EbookControllerTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testEbookControllerShouldThrowNotFoundHttpException()
+    {
+        $ebookRepository = $this->createMock('AppBundle\Repository\EbookRepository');
+        $ebookRepository->method('findBySlug')
+            ->willReturn(null);
+
+        $ebookSlug = 'no-ebook';
+
+        $ebookController = new EbookController($ebookRepository);
+        $ebookController->ebookAction($ebookSlug);
+    }
+}


### PR DESCRIPTION
## Description

- Replace development to production route in `school learning pages`.
- Enable Tooltip and Popover in school learning pages.
- Use ProficiencyCssClass Filter in school learning pages.
- Add School Learning functional tests.
- Add EbookControllerTest.

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub

Migration of school learning page.

## Screenshot

![screen shot 2018-07-30 at 4 17 57 pm](https://user-images.githubusercontent.com/1117674/43418405-27bc2fdc-9414-11e8-9aab-5b0863e04e74.png)

