### PR TITLE
Add AMP link in school learning pages

### DIFF
--- a/app/Resources/views/learning/school.html.twig
+++ b/app/Resources/views/learning/school.html.twig
@@ -16,6 +16,9 @@
   <link type="text/css" href="/gimme/d3e1a7d09b/pkg/css/provabrasil.css" rel="stylesheet">
   <link type="text/css" href="/gimme/cfdcda464f/pkg/css/provabrasil/dropdown-select2.css" rel="stylesheet"/>
   <link type="text/css" href="/gimme/c17a152ffb/pkg/css/provabrasil/banner.css" rel="stylesheet"/>
+
+  <link rel="amphtml" href="{{ url('learning_school_amp', {'schoolId': school.getId(), 'schoolSlug': school.getSlug()}) }}">
+
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Description

- Add AMP link in school learning pages.

## Motivation and context

> *K.R. 2.2* - Migrate more than 50% of page views to QEdu Hub