### PR TITLE
Include Enem results

### DIFF
--- a/app/Resources/views/enem/more_info.html.twig
+++ b/app/Resources/views/enem/more_info.html.twig
@@ -1,0 +1,30 @@
+<section class="enem-more-info">
+  <header class="container">
+    <h2>Mais informações sobre o Enem</h2>
+  </header>
+  <div class="more-info-ct">
+    <div class="more-info-links-ct container">
+      <div class="more-info-link-ct span4">
+        <a target="_blank" href="http://www.mec.gov.br" class="more-info-link link-prouni">
+          <span class="link-icon-border"><span class="link-icon"></span></span>
+          <h3>Prouni e Sisu</h3>
+          <p>Entenda como o seu resultado no Enem pode lhe ajudar a entrar nas melhores universidades do Brasil.</p>
+        </a>
+      </div>
+      <div class="more-info-link-ct span4">
+        <a target="_blank" href="http://enem.inep.gov.br" class="more-info-link link-enem">
+          <span class="link-icon-border"><span class="link-icon"></span></span>
+          <h3>Inscrição no Enem</h3>
+          <p>Você é estudante e quer fazer o exame? Veja todas as informações a respeito do Enem.</p>
+        </a>
+      </div>
+      <div class="more-info-link-ct span4">
+        <a target="_blank" href="http://portal.inep.gov.br/web/enem/enem" class="more-info-link link-inep">
+          <span class="link-icon-border"><span class="link-icon"></span></span>
+          <h3>Resultados oficiais do Inep</h3>
+          <p>Sistema de informações, pesquisas e estatísticas do MEC. Veja também publicações e outras avaliações.</p>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/Resources/views/enem/school.html.twig
+++ b/app/Resources/views/enem/school.html.twig
@@ -6,6 +6,7 @@
 {% set schoolRecord = content.getEnemSchoolRecord() %}
 {% set schoolParticipation = schoolRecord.getEnemSchoolParticipation() %}
 {% set schoolParticipationRate = schoolParticipation.getParticipationRate() * 100 %}
+{% set schoolResults = schoolRecord.getEnemSchoolResults() %}
 
 {% block stylesheets %}
   <link type="text/css" href="/gimme/1cb1adaa50/pkg/css/provabrasil.css" rel="stylesheet" />
@@ -25,6 +26,8 @@
     {% include 'enem/filter.html.twig' %}
 
     {% include 'enem/school/participation_rate.html.twig' %}
+
+    {% include 'enem/school/results/human_sciences.html.twig' %}
 
   </section>
 {% endblock %}

--- a/app/Resources/views/enem/school.html.twig
+++ b/app/Resources/views/enem/school.html.twig
@@ -29,7 +29,18 @@
 
     {% include 'enem/school/results/human_sciences.html.twig' %}
 
+    {% include 'enem/school/results/natural_sciences.html.twig' %}
+
+    {% include 'enem/school/results/languages_and_codes.html.twig' %}
+
+    {% include 'enem/school/results/mathematics.html.twig' %}
+
+    {% include 'enem/school/results/essay.html.twig' %}
+
   </section>
+
+  {% include 'enem/more_info.html.twig' %}
+
 {% endblock %}
 
 {% block javascripts %}

--- a/app/Resources/views/enem/school.html.twig
+++ b/app/Resources/views/enem/school.html.twig
@@ -5,8 +5,6 @@
 {% set filter = content.getFilter() %}
 {% set schoolRecord = content.getEnemSchoolRecord() %}
 {% set schoolParticipation = schoolRecord.getEnemSchoolParticipation() %}
-{% set schoolParticipationRate = schoolParticipation.getParticipationRate() * 100 %}
-{% set schoolResults = schoolRecord.getEnemSchoolResults() %}
 
 {% block stylesheets %}
   <link type="text/css" href="/gimme/1cb1adaa50/pkg/css/provabrasil.css" rel="stylesheet" />
@@ -25,17 +23,23 @@
 
     {% include 'enem/filter.html.twig' %}
 
-    {% include 'enem/school/participation_rate.html.twig' %}
+    {% if schoolParticipation is null %}
 
-    {% include 'enem/school/results/human_sciences.html.twig' %}
+      <p class="data-notification">Não há resultado do Enem para esta escola neste ano.</p>
 
-    {% include 'enem/school/results/natural_sciences.html.twig' %}
+    {% else %}
 
-    {% include 'enem/school/results/languages_and_codes.html.twig' %}
+      {% set schoolParticipationRate = schoolParticipation.getParticipationRate() * 100 %}
+      {% set schoolResults = schoolRecord.getEnemSchoolResults() %}
 
-    {% include 'enem/school/results/mathematics.html.twig' %}
+      {% include 'enem/school/participation_rate.html.twig' %}
+      {% include 'enem/school/results/human_sciences.html.twig' %}
+      {% include 'enem/school/results/natural_sciences.html.twig' %}
+      {% include 'enem/school/results/languages_and_codes.html.twig' %}
+      {% include 'enem/school/results/mathematics.html.twig' %}
+      {% include 'enem/school/results/essay.html.twig' %}
 
-    {% include 'enem/school/results/essay.html.twig' %}
+    {% endif %}
 
   </section>
 

--- a/app/Resources/views/enem/school.html.twig
+++ b/app/Resources/views/enem/school.html.twig
@@ -24,28 +24,7 @@
 
     {% include 'enem/filter.html.twig' %}
 
-    <div class="enem-results row participation-rate">
-      <header class="span12 enem-header">
-        <h1>Taxa de participação</h1>
-      </header>
-      <div class="span4 score-ct">
-        <p class="score"><span class="value">{{ schoolParticipationRate|number_format }}</span>%</p>
-        <p class="description"><strong>{{ schoolParticipation.getParticipationCount() }} alunos participantes</strong><br>nos dois dias da avaliação</p>
-      </div>
-      <div class="span5 main-ct">
-        <div class="content-ct">
-          <p>Esta é a proporção de alunos da escola que participaram desta edição do Enem. Você deve usar este valor para entender qual a representatividade dos resultados do Enem para a sua escola.</p>
-          <p>O Inep só disponibiliza dados quando a taxa de participação é maior ou igual a 50%. Isso é feito porque resultados com baixa participação não podem ser considerados como representativos da escola.</p>
-          <p>
-            <i class="glyphicon glyphicon-chevron-right"></i>
-            <a target="_blank" href="/ajuda/artigo/446051">Saiba mais sobre a participação no Enem no Brasil</a>
-          </p>
-        </div>
-      </div>
-      <div class="span3">
-        <a target="_blank" href="/ajuda/artigo/446051" class="participation-map">Veja o mapa da participação</a>
-      </div>
-    </div>
+    {% include 'enem/school/participation_rate.html.twig' %}
 
   </section>
 {% endblock %}

--- a/app/Resources/views/enem/school.html.twig
+++ b/app/Resources/views/enem/school.html.twig
@@ -45,6 +45,14 @@
 
   {% include 'enem/more_info.html.twig' %}
 
+  <script type="text/html" id="tmp-compare-note">
+    <p class="compare-note">Os dados desta escola não são representativos.<a target="_blank" href="/ajuda/artigo/446100">Saiba mais</a>.</p>
+  </script>
+
+  <script type="text/html" id="tmp-compare-sign">
+    <span class="compare-sign">*</span>
+  </script>
+
 {% endblock %}
 
 {% block javascripts %}
@@ -66,6 +74,10 @@
             "baseUrl": "\/escola\/{{ school.getId() }}-{{ school.getSlug() }}\/enem-dev",
             "edition": {{ filter.getCurrentYear() }},
             "educationNetworkTypeId": null
+        }],
+
+        "Meritt\/QEdu\/UI\/Enem\/Assets\/js\/Compare": [{
+            "canBeCompared": {{ schoolParticipation and schoolRecord.isRepresentative() ? 'true' : 'false' }}
         }],
 
         {% include 'breadcrumb.html.twig' %}

--- a/app/Resources/views/enem/school/participation_rate.html.twig
+++ b/app/Resources/views/enem/school/participation_rate.html.twig
@@ -1,0 +1,27 @@
+<div class="enem-results row participation-rate">
+  <header class="span12 enem-header">
+    <h1>Taxa de participação</h1>
+  </header>
+  <div class="span4 score-ct">
+    <p class="score"><span class="value">{{ schoolParticipationRate|number_format }}</span>%</p>
+    <p class="description"><strong>{{ schoolParticipation.getParticipationCount() }} alunos participantes</strong><br>nos dois dias da avaliação</p>
+  </div>
+  <div class="span5 main-ct">
+    <div class="content-ct">
+      <p>Esta é a proporção de alunos da escola que participaram desta edição do Enem. Você deve usar este valor para entender qual a representatividade dos resultados do Enem para a sua escola.</p>
+      <p>O Inep só disponibiliza dados quando a taxa de participação é maior ou igual a 50%. Isso é feito porque resultados com baixa participação não podem ser considerados como representativos da escola.</p>
+      <p>
+        <i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446051">Saiba mais sobre a participação no Enem no Brasil</a>
+      </p>
+    </div>
+  </div>
+  <div class="span3">
+    <a target="_blank" href="/ajuda/artigo/446051" class="participation-map">Veja o mapa da participação</a>
+    </div>
+</div>
+
+<p class="source">
+  Fonte: QEdu.org.br. Microdados do Enem/Inep ({{ filter.getCurrentYear() }}).
+  <a target="_blank" href="/ajuda/artigo/446100">Veja Notas Técnicas aqui</a>
+</p>

--- a/app/Resources/views/enem/school/results/essay.html.twig
+++ b/app/Resources/views/enem/school/results/essay.html.twig
@@ -1,0 +1,30 @@
+<div class="enem-results row ro">
+  <header class="span12 enem-header">
+    <h1>Média em Redação</h1>
+  </header>
+  <div class="span4 score-ct">
+    <p class="score"><span class="value">{{ schoolResults.getEssayAverage()|number_format }}</span>pts</p>
+    <p class="description">Média em Redação</p>
+  </div>
+  <div class="span8 main-ct">
+    <div class="span image-ct">
+      <span class="image-border"><span class="image"></span></span>
+    </div>
+
+    <div class="span links-ct">
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446112">Conheça as 5 competências avaliadas nesta área</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446113">Interprete este resultado pedagogicamente com a escala de desempenho de Redação</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446114">Veja como foi o desempenho do Brasil nesta área</a>
+      </p>
+    </div>
+  </div>
+</div>
+<p class="source">
+  Fonte: QEdu.org.br. Microdados do Enem/Inep ({{ filter.getCurrentYear() }}).
+  <a target="_blank" href="/ajuda/artigo/446100">Veja Notas Técnicas aqui</a>
+</p>

--- a/app/Resources/views/enem/school/results/human_sciences.html.twig
+++ b/app/Resources/views/enem/school/results/human_sciences.html.twig
@@ -1,0 +1,33 @@
+<div class="enem-results row cs">
+  <header class="span12 enem-header">
+    <h1>Média em Ciências Humanas</h1>
+    <h2>Geografia, história, filosofia e sociologia</h2>
+  </header>
+  <div class="span4 score-ct">
+    <p class="score"><span class="value">{{ schoolResults.getHumanSciencesAverage()|number_format }}</span>pts</p>
+    <p class="description">Média em Ciências Humanas</p>
+  </div>
+  <div class="span8 main-ct">
+    <div class="span image-ct">
+      <span class="image-border">
+        <span class="image"></span>
+      </span>
+      </div>
+
+      <div class="span links-ct">
+        <p><i class="glyphicon glyphicon-chevron-right"></i>
+          <a target="_blank" href="/ajuda/artigo/446095">Conheça as 6 competências avaliadas nesta área</a>
+        </p>
+        <p><i class="glyphicon glyphicon-chevron-right"></i>
+          <a target="_blank" href="/ajuda/artigo/446097">Interprete este resultado pedagogicamente com a escala de desempenho de Ciências Humanas</a>
+        </p>
+        <p><i class="glyphicon glyphicon-chevron-right"></i>
+          <a target="_blank" href="/ajuda/artigo/446098">Veja como foi o desempenho do Brasil nesta área</a>
+        </p>
+      </div>
+  </div>
+</div>
+<p class="source">
+  Fonte: QEdu.org.br. Microdados do Enem/Inep ({{ filter.getCurrentYear() }}).
+  <a target="_blank" href="/ajuda/artigo/446100">Veja Notas Técnicas aqui</a>
+</p>

--- a/app/Resources/views/enem/school/results/languages_and_codes.html.twig
+++ b/app/Resources/views/enem/school/results/languages_and_codes.html.twig
@@ -1,0 +1,31 @@
+<div class="enem-results row ls">
+  <header class="span12 enem-header">
+    <h1>Média em Linguagens e Códigos</h1>
+    <h2>Português, artes, educação física, inglês e espanhol</h2>
+  </header>
+  <div class="span4 score-ct">
+    <p class="score"><span class="value">{{ schoolResults.getLanguagesAndCodesAverage()|number_format }}</span>pts</p>
+    <p class="description">Média em Linguagens e Códigos</p>
+  </div>
+  <div class="span8 main-ct">
+    <div class="span image-ct">
+      <span class="image-border"><span class="image"></span></span>
+    </div>
+
+    <div class="span links-ct">
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446102">Conheça as 9 competências avaliadas nesta área</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446105">Interprete este resultado pedagogicamente com a escala de desempenho de Linguagens e Códigos</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446109">Veja como foi o desempenho do Brasil nesta área</a>
+      </p>
+    </div>
+  </div>
+</div>
+<p class="source">
+    Fonte: QEdu.org.br. Microdados do Enem/Inep ({{ filter.getCurrentYear() }}).
+    <a target="_blank" href="/ajuda/artigo/446100">Veja Notas Técnicas aqui</a>
+</p>

--- a/app/Resources/views/enem/school/results/mathematics.html.twig
+++ b/app/Resources/views/enem/school/results/mathematics.html.twig
@@ -1,0 +1,30 @@
+<div class="enem-results row ma">
+  <header class="span12 enem-header">
+    <h1>Média em Matemática</h1>
+  </header>
+  <div class="span4 score-ct">
+    <p class="score"><span class="value">{{ schoolResults.getMathematicsAverage()|number_format }}</span>pts</p>
+    <p class="description">Média em Matemática</p>
+  </div>
+  <div class="span8 main-ct">
+    <div class="span image-ct">
+      <span class="image-border"><span class="image"></span></span>
+    </div>
+
+    <div class="span links-ct">
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446103">Conheça as 7 competências avaliadas nesta área</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446106">Interprete este resultado pedagogicamente com a escala de desempenho de Matemática</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446110">Veja como foi o desempenho do Brasil nesta área</a>
+      </p>
+    </div>
+  </div>
+</div>
+<p class="source">
+  Fonte: QEdu.org.br. Microdados do Enem/Inep ({{ filter.getCurrentYear() }}).
+  <a target="_blank" href="/ajuda/artigo/446100">Veja Notas Técnicas aqui</a>
+</p>

--- a/app/Resources/views/enem/school/results/natural_sciences.html.twig
+++ b/app/Resources/views/enem/school/results/natural_sciences.html.twig
@@ -1,0 +1,33 @@
+<div class="enem-results row ca">
+  <header class="span12 enem-header">
+    <h1>Média em Ciências da Natureza</h1>
+    <h2>Física, química e biologia</h2>
+  </header>
+  <div class="span4 score-ct">
+    <p class="score"><span class="value">{{ schoolResults.getNaturalSciencesAverage()|number_format }}</span>pts</p>
+    <p class="description">Média em Ciências da Natureza</p>
+  </div>
+  <div class="span8 main-ct">
+    <div class="span image-ct">
+      <span class="image-border">
+        <span class="image"></span>
+      </span>
+    </div>
+
+    <div class="span links-ct">
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446101">Conheça as 8 competências avaliadas nesta área</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446104">Interprete este resultado pedagogicamente com a escala de desempenho de Ciências da Natureza</a>
+      </p>
+      <p><i class="glyphicon glyphicon-chevron-right"></i>
+        <a target="_blank" href="/ajuda/artigo/446108">Veja como foi o desempenho do Brasil nesta área</a>
+      </p>
+    </div>
+  </div>
+</div>
+<p class="source">
+  Fonte: QEdu.org.br. Microdados do Enem/Inep ({{ filter.getCurrentYear() }}).
+  <a target="_blank" href="/ajuda/artigo/446100">Veja Notas Técnicas aqui</a>
+</p>

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -54,6 +54,10 @@ services:
         factory: 'doctrine.orm.qedu_entity_manager:getRepository'
         arguments: ['AppBundle\Entity\Enem\EnemSchoolParticipation']
 
+    AppBundle\Repository\Enem\EnemSchoolResultsRepository:
+            factory: 'doctrine.orm.qedu_entity_manager:getRepository'
+            arguments: ['AppBundle\Entity\Enem\EnemSchoolResults']
+
     AppBundle\Repository\ProficiencyRepositoryInterface: '@AppBundle\Repository\ProficiencyRepository'
 
     AppBundle\Repository\Learning\SchoolRepositoryInterface: '@AppBundle\Repository\Learning\SchoolRepository'
@@ -62,4 +66,6 @@ services:
 
     AppBundle\Repository\Census\SchoolRepositoryInterface: '@AppBundle\Repository\Census\SchoolRepository'
 
-    AppBundle\Repository\Enem\EnemSchoolRepositoryInterface: '@AppBundle\Repository\Enem\EnemSchoolParticipationRepository'
+    AppBundle\Repository\Enem\EnemSchoolParticipationRepositoryInterface: '@AppBundle\Repository\Enem\EnemSchoolParticipationRepository'
+
+    AppBundle\Repository\Enem\EnemSchoolResultsRepositoryInterface: '@AppBundle\Repository\Enem\EnemSchoolResultsRepository'

--- a/src/AppBundle/Enem/EnemFilter.php
+++ b/src/AppBundle/Enem/EnemFilter.php
@@ -22,8 +22,8 @@ class EnemFilter
 
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
-        EnemEditionSelected $enemEditionSelected)
-    {
+        EnemEditionSelected $enemEditionSelected
+    ) {
         $this->authorizationChecker = $authorizationChecker;
         $this->enemEditionSelected = $enemEditionSelected;
     }

--- a/src/AppBundle/Enem/EnemSchoolRecord.php
+++ b/src/AppBundle/Enem/EnemSchoolRecord.php
@@ -27,4 +27,16 @@ class EnemSchoolRecord
     {
         return $this->enemSchoolResults;
     }
+
+    public function isRepresentative() : bool
+    {
+        $participationRate = $this->enemSchoolParticipation->getParticipationRate();
+        $participationCount = $this->enemSchoolParticipation->getParticipationCount();
+
+        if ($participationRate < 0.5 || $participationCount < 10) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/AppBundle/Enem/EnemSchoolRecord.php
+++ b/src/AppBundle/Enem/EnemSchoolRecord.php
@@ -3,18 +3,28 @@
 namespace AppBundle\Enem;
 
 use AppBundle\Entity\Enem\EnemSchoolParticipation;
+use AppBundle\Entity\Enem\EnemSchoolResults;
 
 class EnemSchoolRecord
 {
     private $enemSchoolParticipation;
+    private $enemSchoolResults;
 
-    public function __construct(?EnemSchoolParticipation $enemSchoolParticipation)
-    {
+    public function __construct(
+        ?EnemSchoolParticipation $enemSchoolParticipation,
+        ?EnemSchoolResults $enemSchoolResults
+    ) {
         $this->enemSchoolParticipation = $enemSchoolParticipation;
+        $this->enemSchoolResults = $enemSchoolResults;
     }
 
     public function getEnemSchoolParticipation()
     {
         return $this->enemSchoolParticipation;
+    }
+
+    public function getEnemSchoolResults()
+    {
+        return $this->enemSchoolResults;
     }
 }

--- a/src/AppBundle/Enem/EnemService.php
+++ b/src/AppBundle/Enem/EnemService.php
@@ -3,26 +3,40 @@
 namespace AppBundle\Enem;
 
 use AppBundle\Entity\School;
-use AppBundle\Repository\Enem\EnemSchoolRepositoryInterface;
+use AppBundle\Repository\Enem\EnemSchoolParticipationRepositoryInterface;
+use AppBundle\Repository\Enem\EnemSchoolResultsRepositoryInterface;
 
 class EnemService implements EnemServiceInterface
 {
-    private $schoolRepository;
+    private $schoolParticipationRepository;
+    private $schoolResultsRepository;
     private $enemEditionSelected;
 
     public function __construct(
-        EnemSchoolRepositoryInterface $schoolRepository,
+        EnemSchoolParticipationRepositoryInterface $schoolParticipationRepository,
+        EnemSchoolResultsRepositoryInterface $schoolResultsRepository,
         EnemEditionSelected $enemEditionSelected
     ) {
-        $this->schoolRepository = $schoolRepository;
+        $this->schoolParticipationRepository = $schoolParticipationRepository;
+        $this->schoolResultsRepository = $schoolResultsRepository;
         $this->enemEditionSelected = $enemEditionSelected;
     }
 
     public function getEnemByEdition(School $school)
     {
         $enemEdition = $this->enemEditionSelected->getEnemEdition();
-        $enemSchoolParticipation = $this->schoolRepository->findEnemSchoolParticipationByEdition($school, $enemEdition);
-        $enemSchoolRecord = new EnemSchoolRecord($enemSchoolParticipation);
+
+        $enemSchoolParticipation = $this->schoolParticipationRepository
+            ->findEnemSchoolParticipationByEdition($school, $enemEdition);
+
+        if (!$enemSchoolParticipation) {
+            return new EnemSchoolRecord(null, null);
+        }
+
+        $enemSchoolResults = $this->schoolResultsRepository
+            ->findEnemSchoolResultsByEnemSchoolParticipation($enemSchoolParticipation);
+
+        $enemSchoolRecord = new EnemSchoolRecord($enemSchoolParticipation, $enemSchoolResults);
 
         return $enemSchoolRecord;
     }

--- a/src/AppBundle/Entity/Enem/EnemSchoolResults.php
+++ b/src/AppBundle/Entity/Enem/EnemSchoolResults.php
@@ -5,16 +5,16 @@ namespace AppBundle\Entity\Enem;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * SchoolResults
+ * EnemSchoolResults
  *
  * @ORM\Table(name="enem_school_results",
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="UNIQ_C08EF8889E8F7F4E", columns={"schoolParticipation_id"})
  *     }
  * )
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="AppBundle\Repository\Enem\EnemSchoolResultsRepository")
  */
-class SchoolResults
+class EnemSchoolResults
 {
     /**
      * @var integer
@@ -61,12 +61,39 @@ class SchoolResults
     private $essayAverage;
 
     /**
-     * @var \AppBundle\Entity\Enem\EnemSchoolParticipation
+     * @var integer
      *
-     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Enem\EnemSchoolParticipation")
-     * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="schoolParticipation_id", referencedColumnName="id")
-     * })
+     * @ORM\Column(name="schoolParticipation_id", type="integer", nullable=false)
      */
-    private $schoolParticipation;
+    private $schoolParticipationId;
+
+    public function getLanguagesAndCodesAverage(): string
+    {
+        return $this->languagesAndCodesAverage;
+    }
+
+    public function getMathematicsAverage(): string
+    {
+        return $this->mathematicsAverage;
+    }
+
+    public function getHumanSciencesAverage(): string
+    {
+        return $this->humanSciencesAverage;
+    }
+
+    public function getNaturalSciencesAverage(): string
+    {
+        return $this->naturalSciencesAverage;
+    }
+
+    public function getEssayAverage(): string
+    {
+        return $this->essayAverage;
+    }
+
+    public function getSchoolParticipationId(): int
+    {
+        return $this->schoolParticipationId;
+    }
 }

--- a/src/AppBundle/Repository/Enem/EnemSchoolParticipationRepository.php
+++ b/src/AppBundle/Repository/Enem/EnemSchoolParticipationRepository.php
@@ -8,13 +8,13 @@ use AppBundle\Entity\School;
 
 use Doctrine\ORM\EntityRepository;
 
-class EnemSchoolParticipationRepository extends EntityRepository implements EnemSchoolRepositoryInterface
+class EnemSchoolParticipationRepository extends EntityRepository implements EnemSchoolParticipationRepositoryInterface
 {
     public function findEnemSchoolParticipationByEdition(School $school, EnemEdition $enemEdition)
     {
         $queryBuilder = $this->createQueryBuilder('esp');
 
-        return $queryBuilder->join(EducationEntity::class, 'ee', 'WITH', 'esp.schoolId = ee.id AND ee.type = \'school\'')
+        return $queryBuilder->join(EducationEntity::class, 'ee', 'WITH', "esp.schoolId = ee.id AND ee.type = 'school'")
             ->andWhere('esp.edition = ' . $enemEdition->getYear())
             ->andWhere('ee.oldId = ' . $school->getId())
             ->getQuery()

--- a/src/AppBundle/Repository/Enem/EnemSchoolParticipationRepositoryInterface.php
+++ b/src/AppBundle/Repository/Enem/EnemSchoolParticipationRepositoryInterface.php
@@ -5,7 +5,7 @@ namespace AppBundle\Repository\Enem;
 use AppBundle\Entity\School;
 use AppBundle\Enem\EnemEdition;
 
-interface EnemSchoolRepositoryInterface
+interface EnemSchoolParticipationRepositoryInterface
 {
     public function findEnemSchoolParticipationByEdition(School $school, EnemEdition $enemEdition);
 }

--- a/src/AppBundle/Repository/Enem/EnemSchoolResultsRepository.php
+++ b/src/AppBundle/Repository/Enem/EnemSchoolResultsRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AppBundle\Repository\Enem;
+
+use AppBundle\Entity\Enem\EnemSchoolParticipation;
+use Doctrine\ORM\EntityRepository;
+
+class EnemSchoolResultsRepository extends EntityRepository implements EnemSchoolResultsRepositoryInterface
+{
+    public function findEnemSchoolResultsByEnemSchoolParticipation(EnemSchoolParticipation $enemSchoolParticipation)
+    {
+        $queryBuilder = $this->createQueryBuilder('esr');
+
+        return $queryBuilder->andWhere('esr.schoolParticipationId = ' . $enemSchoolParticipation->getId())
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/AppBundle/Repository/Enem/EnemSchoolResultsRepositoryInterface.php
+++ b/src/AppBundle/Repository/Enem/EnemSchoolResultsRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AppBundle\Repository\Enem;
+
+use AppBundle\Entity\Enem\EnemSchoolParticipation;
+
+interface EnemSchoolResultsRepositoryInterface
+{
+    public function findEnemSchoolResultsByEnemSchoolParticipation(EnemSchoolParticipation $enemSchoolParticipation);
+}

--- a/tests/fixture/Database/EducationEntityTableFixture.php
+++ b/tests/fixture/Database/EducationEntityTableFixture.php
@@ -48,7 +48,8 @@ VALUES
 	(1, NULL, NULL, 'brasil', 'Brasil', 'BR', 100, 'country'),
 	(26, 1, 35, 'sao-paulo', 'São Paulo', 'SP', 125, 'state'),
 	(3383, 26, 3550308, 'sao-paulo', 'São Paulo', 'SAO PAULO', 2329, 'city'),
-	(90356, 3383, 35107542, 'pueri-domus-escola-verbo-divino-unidade-i', 'PUERI DOMUS ESCOLA VERBO DIVINO UNIDADE I', 'PUERI DOMUS ESCOLA VERBO DIVINO UNIDADE I', 212104, 'school');
+	(90356, 3383, 35107542, 'pueri-domus-escola-verbo-divino-unidade-i', 'PUERI DOMUS ESCOLA VERBO DIVINO UNIDADE I',
+	 'PUERI DOMUS ESCOLA VERBO DIVINO UNIDADE I', 212104, 'school');
 SQL
             )->execute();
     }

--- a/tests/fixture/Database/EnemSchoolResultsTableFixture.php
+++ b/tests/fixture/Database/EnemSchoolResultsTableFixture.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Fixture\Database;
+
+class EnemSchoolResultsTableFixture extends AbstractDatabase
+{
+    use QeduTrait;
+
+    public function createTable($kernel)
+    {
+        $this->createDatabase($kernel);
+
+        $this->loadEntityManager($kernel);
+
+        $this->createEnemSchoolResultsTable();
+    }
+
+    public function createEnemSchoolResultsTable()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+CREATE TABLE `enem_school_results` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `averageLc` decimal(5,2) NOT NULL,
+  `averageMt` decimal(5,2) NOT NULL,
+  `averageCh` decimal(5,2) NOT NULL,
+  `averageCn` decimal(5,2) NOT NULL,
+  `averageRed` decimal(6,2) NOT NULL,
+  `schoolParticipation_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UNIQ_C08EF8889E8F7F4E` (`schoolParticipation_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=204195 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+SQL
+            )->execute();
+    }
+
+    public function populateWithEnemSchoolResultsRegister()
+    {
+        $this->entityManager->getConnection()
+            ->prepare(<<<SQL
+INSERT INTO `enem_school_results` (`id`, `averageLc`, `averageMt`, `averageCh`, `averageCn`, `averageRed`,
+ `schoolParticipation_id`)
+VALUES
+	(43550, 429.00, 406.75, 444.25, 373.50, 500.00, 65434),
+	(43551, 409.83, 433.83, 467.07, 422.03, 487.50, 65441),
+	(43552, 498.50, 485.00, 507.50, 509.50, 662.50, 65446),
+	(43553, 548.00, 532.50, 513.50, 491.00, 625.00, 65447),
+	(117324, 603.44, 663.97, 619.42, 578.47, 648.03, 117324),
+	(132691, 583.01, 612.53, 617.11, 556.02, 623.53, 129433),
+	(147985, 525.26, 489.33, 561.57, 473.76, 580.00, 146846),
+	(174410, 493.01, 451.77, 502.37, 440.66, 441.82, 179925);
+SQL
+            )->execute();
+    }
+}

--- a/tests/integration/AppBundle/Repository/Enem/EnemSchoolParticipationRepositoryTest.php
+++ b/tests/integration/AppBundle/Repository/Enem/EnemSchoolParticipationRepositoryTest.php
@@ -7,7 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Tests\Fixture\Database\EducationEntityTableFixture;
 use Tests\Fixture\Database\EnemSchoolParticipationTableFixture;
 
-class EnemParticipationRepositoryTest extends KernelTestCase
+class EnemSchoolParticipationRepositoryTest extends KernelTestCase
 {
     private $enemSchoolParticipationTableFixture;
     private $educationEntityTableFixture;

--- a/tests/integration/AppBundle/Repository/Enem/EnemSchoolResultsRepositoryTest.php
+++ b/tests/integration/AppBundle/Repository/Enem/EnemSchoolResultsRepositoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Integration\AppBundle\Repository\Enem;
+
+use AppBundle\Entity\Enem\EnemSchoolResults;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Fixture\Database\EnemSchoolResultsTableFixture;
+
+class EnemSchoolResultsRepositoryTest extends KernelTestCase
+{
+    private $enemSchoolResultsTableFixture;
+    private $emEnemResults;
+
+    public function testFindEnemSchoolResultsByEnemSchoolParticipation()
+    {
+        $enemSchoolParticipation = $this->createMock('AppBundle\Entity\Enem\EnemSchoolParticipation');
+        $enemSchoolParticipation->method('getId')
+            ->willReturn(179925);
+
+        $schoolResults = $this->emEnemResults
+            ->getRepository(EnemSchoolResults::class)
+            ->findEnemSchoolResultsByEnemSchoolParticipation($enemSchoolParticipation);
+
+        $expectedAverageHumanSciences = 502.37;
+        $expectedAverageNaturalSciences = 440.66;
+        $expectedAverageLanguagesAndCodes = 493.01;
+        $expectedAverageMath = 451.77;
+        $expectedAverageEssay = 441.82;
+
+        $this->assertEquals($expectedAverageHumanSciences, $schoolResults->getHumanSciencesAverage());
+        $this->assertEquals($expectedAverageNaturalSciences, $schoolResults->getNaturalSciencesAverage());
+        $this->assertEquals($expectedAverageLanguagesAndCodes, $schoolResults->getLanguagesAndCodesAverage());
+        $this->assertEquals($expectedAverageMath, $schoolResults->getMathematicsAverage());
+        $this->assertEquals($expectedAverageEssay, $schoolResults->getEssayAverage());
+    }
+
+    protected function setUp()
+    {
+        $kernel = self::bootKernel();
+
+        $this->enemSchoolResultsTableFixture = new EnemSchoolResultsTableFixture();
+        $this->enemSchoolResultsTableFixture->createTable($kernel);
+        $this->enemSchoolResultsTableFixture->populateWithEnemSchoolResultsRegister();
+
+        $this->emEnemResults = $this->enemSchoolResultsTableFixture->getEntityManager();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->enemSchoolResultsTableFixture->dropTable();
+    }
+}

--- a/tests/unit/AppBundle/Enem/EnemSchoolRecordTest.php
+++ b/tests/unit/AppBundle/Enem/EnemSchoolRecordTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\AppBundle\Enem;
 
 use AppBundle\Enem\EnemSchoolRecord;
+use AppBundle\Enem\EnemService;
 use PHPUnit\Framework\TestCase;
 
 class EnemSchoolRecordTest extends TestCase
@@ -10,9 +11,23 @@ class EnemSchoolRecordTest extends TestCase
     public function testGetEnemSchoolRecordShouldReturnSchoolParticipation()
     {
         $enemSchoolParticipation = $this->createMock('AppBundle\Entity\Enem\EnemSchoolParticipation');
+        $enemSchoolResults = null;
 
-        $enemSchoolRecord = new EnemSchoolRecord($enemSchoolParticipation);
+        $enemSchoolRecord = new EnemSchoolRecord($enemSchoolParticipation, $enemSchoolResults);
 
-        $this->assertInstanceOf('AppBundle\Entity\Enem\EnemSchoolParticipation', $enemSchoolRecord->getEnemSchoolParticipation());
+        $this->assertInstanceOf(
+            'AppBundle\Entity\Enem\EnemSchoolParticipation',
+            $enemSchoolRecord->getEnemSchoolParticipation()
+        );
+    }
+
+    public function testGetEnemSchoolRecordShouldReturnSchoolResults()
+    {
+        $enemSchoolParticipation = null;
+        $enemSchoolResults = $this->createMock('AppBundle\Entity\Enem\EnemSchoolResults');
+
+        $enemSchoolRecord = new EnemSchoolRecord($enemSchoolParticipation, $enemSchoolResults);
+
+        $this->assertInstanceOf('AppBundle\Entity\Enem\EnemSchoolResults', $enemSchoolRecord->getEnemSchoolResults());
     }
 }

--- a/tests/unit/AppBundle/Enem/EnemSchoolRecordTest.php
+++ b/tests/unit/AppBundle/Enem/EnemSchoolRecordTest.php
@@ -30,4 +30,35 @@ class EnemSchoolRecordTest extends TestCase
 
         $this->assertInstanceOf('AppBundle\Entity\Enem\EnemSchoolResults', $enemSchoolRecord->getEnemSchoolResults());
     }
+
+    /**
+     * @dataProvider enemDataProvider
+     */
+    public function testIsEnemRepresentative($participationRate, $participationCount, $expected)
+    {
+        $enemSchoolParticipation = $this->createMock('AppBundle\Entity\Enem\EnemSchoolParticipation');
+        $enemSchoolParticipation->method('getParticipationRate')
+            ->willReturn($participationRate);
+        $enemSchoolParticipation->method('getParticipationCount')
+            ->willReturn($participationCount);
+
+        $enemSchoolResults = $this->createMock('AppBundle\Entity\Enem\EnemSchoolResults');
+
+        $enemSchoolRecord = new EnemSchoolRecord($enemSchoolParticipation, $enemSchoolResults);
+
+        $this->assertEquals($expected, $enemSchoolRecord->isRepresentative());
+    }
+
+    public function enemDataProvider()
+    {
+        return [
+            ['0.34', 34, false],
+            ['0.14', 1, false],
+            ['0.6', 9, false],
+            ['0.49', 11, false],
+            ['0.51', 9, false],
+
+            ['0.7', 50, true],
+        ];
+    }
 }

--- a/tests/unit/AppBundle/Enem/EnemServiceTest.php
+++ b/tests/unit/AppBundle/Enem/EnemServiceTest.php
@@ -10,10 +10,19 @@ class EnemServiceTest extends TestCase
 {
     public function testEnemServiceShouldImplementsEnemServiceInterface()
     {
-        $schoolRepository = $this->createMock('AppBundle\Repository\Enem\EnemSchoolRepositoryInterface');
+        $enemSchoolParticipationRepository = $this->createMock(
+            'AppBundle\Repository\Enem\EnemSchoolParticipationRepositoryInterface'
+        );
+        $enemSchoolResultsRepository = $this->createMock(
+            'AppBundle\Repository\Enem\EnemSchoolResultsRepositoryInterface'
+        );
         $enemEditionSelected = $this->createMock('AppBundle\Enem\EnemEditionSelected');
 
-        $enemService = new EnemService($schoolRepository, $enemEditionSelected);
+        $enemService = new EnemService(
+            $enemSchoolParticipationRepository,
+            $enemSchoolResultsRepository,
+            $enemEditionSelected
+        );
 
         $this->assertInstanceOf('AppBundle\Enem\EnemServiceInterface', $enemService);
     }
@@ -22,7 +31,7 @@ class EnemServiceTest extends TestCase
     {
         $school = $this->createMock('AppBundle\Entity\School');
 
-        $enemSchoolParticipationRepository = $this->getSchoolRepositoryMockWillReturn(
+        $enemSchoolParticipationRepository = $this->getEnemSchoolParticipationRepositoryMockWillReturn(
             $this->createMock('AppBundle\Entity\Enem\EnemSchoolParticipation')
         );
         $enemEditionSelected = $this->createMock('AppBundle\Enem\EnemEditionSelected');
@@ -30,7 +39,15 @@ class EnemServiceTest extends TestCase
             ->method('getEnemEdition')
             ->willReturn(new EnemEdition(2017));
 
-        $enemService = new EnemService($enemSchoolParticipationRepository, $enemEditionSelected);
+        $enemSchoolResultsRepository = $this->createMock(
+            'AppBundle\Repository\Enem\EnemSchoolResultsRepositoryInterface'
+        );
+
+        $enemService = new EnemService(
+            $enemSchoolParticipationRepository,
+            $enemSchoolResultsRepository,
+            $enemEditionSelected
+        );
         $enemSchoolRecord = $enemService->getEnemByEdition($school);
 
         $this->assertInstanceOf('AppBundle\Enem\EnemSchoolRecord', $enemSchoolRecord);
@@ -40,25 +57,33 @@ class EnemServiceTest extends TestCase
     {
         $school = $this->createMock('AppBundle\Entity\School');
 
-        $enemSchoolParticipationRepository = $this->getSchoolRepositoryMockWillReturn(null);
+        $enemSchoolParticipationRepository = $this->getEnemSchoolParticipationRepositoryMockWillReturn(null);
 
         $enemEditionSelected = $this->createMock('AppBundle\Enem\EnemEditionSelected');
         $enemEditionSelected->expects($this->once())
             ->method('getEnemEdition')
             ->willReturn(new EnemEdition(2017));
 
-        $enemService = new EnemService($enemSchoolParticipationRepository, $enemEditionSelected);
+        $enemSchoolResultsRepository = $this->createMock(
+            'AppBundle\Repository\Enem\EnemSchoolResultsRepositoryInterface'
+        );
+
+        $enemService = new EnemService(
+            $enemSchoolParticipationRepository,
+            $enemSchoolResultsRepository,
+            $enemEditionSelected
+        );
         $enemSchoolRecord = $enemService->getEnemByEdition($school);
         $enemSchoolParticipation = $enemSchoolRecord->getEnemSchoolParticipation();
 
         $this->assertNull($enemSchoolParticipation);
     }
 
-    private function getSchoolRepositoryMockWillReturn($return)
+    private function getEnemSchoolParticipationRepositoryMockWillReturn($return)
     {
         $school = $this->createMock('AppBundle\Entity\School');
 
-        $schoolRepository = $this->createMock('AppBundle\Repository\Enem\EnemSchoolRepositoryInterface');
+        $schoolRepository = $this->createMock('AppBundle\Repository\Enem\EnemSchoolParticipationRepositoryInterface');
         $schoolRepository->expects($this->once())
             ->method('findEnemSchoolParticipationByEdition')
             ->with(


### PR DESCRIPTION
## Description
- Include each of Enem results in Enem/School page
- Include red box when Enem results not available
- Include Enem representativeness
- Modify view
- Modify tests

## Motivation and context
> K.R. 3.4 - Migrate one page to QEdu Hub transfering the knowledge to the team.